### PR TITLE
Handle clones/forks of tracked processes

### DIFF
--- a/detector.go
+++ b/detector.go
@@ -168,6 +168,9 @@ func (d *Detector) procEventLoop() {
 		case common.EventTypeExit:
 			pe.EventType = ProcessExitEvent
 			d.output <- pe
+		case common.EventTypeFork:
+			// these events should be handled internally by the probe, and should not be seen by the detector
+			d.l.Error("unexpected fork event", "pid", e.Pid)
 		default:
 			d.l.Error("unknown event type", "type", e.Type)
 		}

--- a/internal/common/process_event.go
+++ b/internal/common/process_event.go
@@ -7,6 +7,7 @@ const (
 	Undefined EventType = iota
 	EventTypeExec
 	EventTypeExit
+	EventTypeFork
 )
 
 type PIDEvent struct {

--- a/internal/headers/bpf_tracing.h
+++ b/internal/headers/bpf_tracing.h
@@ -1,0 +1,492 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+#ifndef __BPF_TRACING_H__
+#define __BPF_TRACING_H__
+
+/* Scan the ARCH passed in from ARCH env variable (see Makefile) */
+#if defined(__TARGET_ARCH_x86)
+	#define bpf_target_x86
+	#define bpf_target_defined
+#elif defined(__TARGET_ARCH_s390)
+	#define bpf_target_s390
+	#define bpf_target_defined
+#elif defined(__TARGET_ARCH_arm)
+	#define bpf_target_arm
+	#define bpf_target_defined
+#elif defined(__TARGET_ARCH_arm64)
+	#define bpf_target_arm64
+	#define bpf_target_defined
+#elif defined(__TARGET_ARCH_mips)
+	#define bpf_target_mips
+	#define bpf_target_defined
+#elif defined(__TARGET_ARCH_powerpc)
+	#define bpf_target_powerpc
+	#define bpf_target_defined
+#elif defined(__TARGET_ARCH_sparc)
+	#define bpf_target_sparc
+	#define bpf_target_defined
+#elif defined(__TARGET_ARCH_riscv)
+	#define bpf_target_riscv
+	#define bpf_target_defined
+#else
+
+/* Fall back to what the compiler says */
+#if defined(__x86_64__)
+	#define bpf_target_x86
+	#define bpf_target_defined
+#elif defined(__s390__)
+	#define bpf_target_s390
+	#define bpf_target_defined
+#elif defined(__arm__)
+	#define bpf_target_arm
+	#define bpf_target_defined
+#elif defined(__aarch64__)
+	#define bpf_target_arm64
+	#define bpf_target_defined
+#elif defined(__mips__)
+	#define bpf_target_mips
+	#define bpf_target_defined
+#elif defined(__powerpc__)
+	#define bpf_target_powerpc
+	#define bpf_target_defined
+#elif defined(__sparc__)
+	#define bpf_target_sparc
+	#define bpf_target_defined
+#elif defined(__riscv) && __riscv_xlen == 64
+	#define bpf_target_riscv
+	#define bpf_target_defined
+#endif /* no compiler target */
+
+#endif
+
+#ifndef __BPF_TARGET_MISSING
+#define __BPF_TARGET_MISSING "GCC error \"Must specify a BPF target arch via __TARGET_ARCH_xxx\""
+#endif
+
+#if defined(bpf_target_x86)
+
+#if defined(__KERNEL__) || defined(__VMLINUX_H__)
+
+#define PT_REGS_PARM1(x) ((x)->di)
+#define PT_REGS_PARM2(x) ((x)->si)
+#define PT_REGS_PARM3(x) ((x)->dx)
+#define PT_REGS_PARM4(x) ((x)->cx)
+#define PT_REGS_PARM5(x) ((x)->r8)
+#define PT_REGS_RET(x) ((x)->sp)
+#define PT_REGS_FP(x) ((x)->bp)
+#define PT_REGS_RC(x) ((x)->ax)
+#define PT_REGS_SP(x) ((x)->sp)
+#define PT_REGS_IP(x) ((x)->ip)
+
+#define PT_REGS_PARM1_CORE(x) BPF_CORE_READ((x), di)
+#define PT_REGS_PARM2_CORE(x) BPF_CORE_READ((x), si)
+#define PT_REGS_PARM3_CORE(x) BPF_CORE_READ((x), dx)
+#define PT_REGS_PARM4_CORE(x) BPF_CORE_READ((x), cx)
+#define PT_REGS_PARM5_CORE(x) BPF_CORE_READ((x), r8)
+#define PT_REGS_RET_CORE(x) BPF_CORE_READ((x), sp)
+#define PT_REGS_FP_CORE(x) BPF_CORE_READ((x), bp)
+#define PT_REGS_RC_CORE(x) BPF_CORE_READ((x), ax)
+#define PT_REGS_SP_CORE(x) BPF_CORE_READ((x), sp)
+#define PT_REGS_IP_CORE(x) BPF_CORE_READ((x), ip)
+
+#else
+
+#ifdef __i386__
+/* i386 kernel is built with -mregparm=3 */
+#define PT_REGS_PARM1(x) ((x)->eax)
+#define PT_REGS_PARM2(x) ((x)->edx)
+#define PT_REGS_PARM3(x) ((x)->ecx)
+#define PT_REGS_PARM4(x) 0
+#define PT_REGS_PARM5(x) 0
+#define PT_REGS_RET(x) ((x)->esp)
+#define PT_REGS_FP(x) ((x)->ebp)
+#define PT_REGS_RC(x) ((x)->eax)
+#define PT_REGS_SP(x) ((x)->esp)
+#define PT_REGS_IP(x) ((x)->eip)
+
+#define PT_REGS_PARM1_CORE(x) BPF_CORE_READ((x), eax)
+#define PT_REGS_PARM2_CORE(x) BPF_CORE_READ((x), edx)
+#define PT_REGS_PARM3_CORE(x) BPF_CORE_READ((x), ecx)
+#define PT_REGS_PARM4_CORE(x) 0
+#define PT_REGS_PARM5_CORE(x) 0
+#define PT_REGS_RET_CORE(x) BPF_CORE_READ((x), esp)
+#define PT_REGS_FP_CORE(x) BPF_CORE_READ((x), ebp)
+#define PT_REGS_RC_CORE(x) BPF_CORE_READ((x), eax)
+#define PT_REGS_SP_CORE(x) BPF_CORE_READ((x), esp)
+#define PT_REGS_IP_CORE(x) BPF_CORE_READ((x), eip)
+
+#else
+
+#define PT_REGS_PARM1(x) ((x)->rdi)
+#define PT_REGS_PARM2(x) ((x)->rsi)
+#define PT_REGS_PARM3(x) ((x)->rdx)
+#define PT_REGS_PARM4(x) ((x)->rcx)
+#define PT_REGS_PARM5(x) ((x)->r8)
+#define PT_REGS_RET(x) ((x)->rsp)
+#define PT_REGS_FP(x) ((x)->rbp)
+#define PT_REGS_RC(x) ((x)->rax)
+#define PT_REGS_SP(x) ((x)->rsp)
+#define PT_REGS_IP(x) ((x)->rip)
+
+#define PT_REGS_PARM1_CORE(x) BPF_CORE_READ((x), rdi)
+#define PT_REGS_PARM2_CORE(x) BPF_CORE_READ((x), rsi)
+#define PT_REGS_PARM3_CORE(x) BPF_CORE_READ((x), rdx)
+#define PT_REGS_PARM4_CORE(x) BPF_CORE_READ((x), rcx)
+#define PT_REGS_PARM5_CORE(x) BPF_CORE_READ((x), r8)
+#define PT_REGS_RET_CORE(x) BPF_CORE_READ((x), rsp)
+#define PT_REGS_FP_CORE(x) BPF_CORE_READ((x), rbp)
+#define PT_REGS_RC_CORE(x) BPF_CORE_READ((x), rax)
+#define PT_REGS_SP_CORE(x) BPF_CORE_READ((x), rsp)
+#define PT_REGS_IP_CORE(x) BPF_CORE_READ((x), rip)
+
+#endif
+#endif
+
+#elif defined(bpf_target_s390)
+
+/* s390 provides user_pt_regs instead of struct pt_regs to userspace */
+struct pt_regs;
+#define PT_REGS_S390 const volatile user_pt_regs
+#define PT_REGS_PARM1(x) (((PT_REGS_S390 *)(x))->gprs[2])
+#define PT_REGS_PARM2(x) (((PT_REGS_S390 *)(x))->gprs[3])
+#define PT_REGS_PARM3(x) (((PT_REGS_S390 *)(x))->gprs[4])
+#define PT_REGS_PARM4(x) (((PT_REGS_S390 *)(x))->gprs[5])
+#define PT_REGS_PARM5(x) (((PT_REGS_S390 *)(x))->gprs[6])
+#define PT_REGS_RET(x) (((PT_REGS_S390 *)(x))->gprs[14])
+/* Works only with CONFIG_FRAME_POINTER */
+#define PT_REGS_FP(x) (((PT_REGS_S390 *)(x))->gprs[11])
+#define PT_REGS_RC(x) (((PT_REGS_S390 *)(x))->gprs[2])
+#define PT_REGS_SP(x) (((PT_REGS_S390 *)(x))->gprs[15])
+#define PT_REGS_IP(x) (((PT_REGS_S390 *)(x))->psw.addr)
+
+#define PT_REGS_PARM1_CORE(x) BPF_CORE_READ((PT_REGS_S390 *)(x), gprs[2])
+#define PT_REGS_PARM2_CORE(x) BPF_CORE_READ((PT_REGS_S390 *)(x), gprs[3])
+#define PT_REGS_PARM3_CORE(x) BPF_CORE_READ((PT_REGS_S390 *)(x), gprs[4])
+#define PT_REGS_PARM4_CORE(x) BPF_CORE_READ((PT_REGS_S390 *)(x), gprs[5])
+#define PT_REGS_PARM5_CORE(x) BPF_CORE_READ((PT_REGS_S390 *)(x), gprs[6])
+#define PT_REGS_RET_CORE(x) BPF_CORE_READ((PT_REGS_S390 *)(x), gprs[14])
+#define PT_REGS_FP_CORE(x) BPF_CORE_READ((PT_REGS_S390 *)(x), gprs[11])
+#define PT_REGS_RC_CORE(x) BPF_CORE_READ((PT_REGS_S390 *)(x), gprs[2])
+#define PT_REGS_SP_CORE(x) BPF_CORE_READ((PT_REGS_S390 *)(x), gprs[15])
+#define PT_REGS_IP_CORE(x) BPF_CORE_READ((PT_REGS_S390 *)(x), psw.addr)
+
+#elif defined(bpf_target_arm)
+
+#define PT_REGS_PARM1(x) ((x)->uregs[0])
+#define PT_REGS_PARM2(x) ((x)->uregs[1])
+#define PT_REGS_PARM3(x) ((x)->uregs[2])
+#define PT_REGS_PARM4(x) ((x)->uregs[3])
+#define PT_REGS_PARM5(x) ((x)->uregs[4])
+#define PT_REGS_RET(x) ((x)->uregs[14])
+#define PT_REGS_FP(x) ((x)->uregs[11]) /* Works only with CONFIG_FRAME_POINTER */
+#define PT_REGS_RC(x) ((x)->uregs[0])
+#define PT_REGS_SP(x) ((x)->uregs[13])
+#define PT_REGS_IP(x) ((x)->uregs[12])
+
+#define PT_REGS_PARM1_CORE(x) BPF_CORE_READ((x), uregs[0])
+#define PT_REGS_PARM2_CORE(x) BPF_CORE_READ((x), uregs[1])
+#define PT_REGS_PARM3_CORE(x) BPF_CORE_READ((x), uregs[2])
+#define PT_REGS_PARM4_CORE(x) BPF_CORE_READ((x), uregs[3])
+#define PT_REGS_PARM5_CORE(x) BPF_CORE_READ((x), uregs[4])
+#define PT_REGS_RET_CORE(x) BPF_CORE_READ((x), uregs[14])
+#define PT_REGS_FP_CORE(x) BPF_CORE_READ((x), uregs[11])
+#define PT_REGS_RC_CORE(x) BPF_CORE_READ((x), uregs[0])
+#define PT_REGS_SP_CORE(x) BPF_CORE_READ((x), uregs[13])
+#define PT_REGS_IP_CORE(x) BPF_CORE_READ((x), uregs[12])
+
+#elif defined(bpf_target_arm64)
+
+/* arm64 provides struct user_pt_regs instead of struct pt_regs to userspace */
+struct pt_regs;
+#define PT_REGS_ARM64 const volatile struct user_pt_regs
+#define PT_REGS_PARM1(x) (((PT_REGS_ARM64 *)(x))->regs[0])
+#define PT_REGS_PARM2(x) (((PT_REGS_ARM64 *)(x))->regs[1])
+#define PT_REGS_PARM3(x) (((PT_REGS_ARM64 *)(x))->regs[2])
+#define PT_REGS_PARM4(x) (((PT_REGS_ARM64 *)(x))->regs[3])
+#define PT_REGS_PARM5(x) (((PT_REGS_ARM64 *)(x))->regs[4])
+#define PT_REGS_RET(x) (((PT_REGS_ARM64 *)(x))->regs[30])
+/* Works only with CONFIG_FRAME_POINTER */
+#define PT_REGS_FP(x) (((PT_REGS_ARM64 *)(x))->regs[29])
+#define PT_REGS_RC(x) (((PT_REGS_ARM64 *)(x))->regs[0])
+#define PT_REGS_SP(x) (((PT_REGS_ARM64 *)(x))->sp)
+#define PT_REGS_IP(x) (((PT_REGS_ARM64 *)(x))->pc)
+
+#define PT_REGS_PARM1_CORE(x) BPF_CORE_READ((PT_REGS_ARM64 *)(x), regs[0])
+#define PT_REGS_PARM2_CORE(x) BPF_CORE_READ((PT_REGS_ARM64 *)(x), regs[1])
+#define PT_REGS_PARM3_CORE(x) BPF_CORE_READ((PT_REGS_ARM64 *)(x), regs[2])
+#define PT_REGS_PARM4_CORE(x) BPF_CORE_READ((PT_REGS_ARM64 *)(x), regs[3])
+#define PT_REGS_PARM5_CORE(x) BPF_CORE_READ((PT_REGS_ARM64 *)(x), regs[4])
+#define PT_REGS_RET_CORE(x) BPF_CORE_READ((PT_REGS_ARM64 *)(x), regs[30])
+#define PT_REGS_FP_CORE(x) BPF_CORE_READ((PT_REGS_ARM64 *)(x), regs[29])
+#define PT_REGS_RC_CORE(x) BPF_CORE_READ((PT_REGS_ARM64 *)(x), regs[0])
+#define PT_REGS_SP_CORE(x) BPF_CORE_READ((PT_REGS_ARM64 *)(x), sp)
+#define PT_REGS_IP_CORE(x) BPF_CORE_READ((PT_REGS_ARM64 *)(x), pc)
+
+#elif defined(bpf_target_mips)
+
+#define PT_REGS_PARM1(x) ((x)->regs[4])
+#define PT_REGS_PARM2(x) ((x)->regs[5])
+#define PT_REGS_PARM3(x) ((x)->regs[6])
+#define PT_REGS_PARM4(x) ((x)->regs[7])
+#define PT_REGS_PARM5(x) ((x)->regs[8])
+#define PT_REGS_RET(x) ((x)->regs[31])
+#define PT_REGS_FP(x) ((x)->regs[30]) /* Works only with CONFIG_FRAME_POINTER */
+#define PT_REGS_RC(x) ((x)->regs[2])
+#define PT_REGS_SP(x) ((x)->regs[29])
+#define PT_REGS_IP(x) ((x)->cp0_epc)
+
+#define PT_REGS_PARM1_CORE(x) BPF_CORE_READ((x), regs[4])
+#define PT_REGS_PARM2_CORE(x) BPF_CORE_READ((x), regs[5])
+#define PT_REGS_PARM3_CORE(x) BPF_CORE_READ((x), regs[6])
+#define PT_REGS_PARM4_CORE(x) BPF_CORE_READ((x), regs[7])
+#define PT_REGS_PARM5_CORE(x) BPF_CORE_READ((x), regs[8])
+#define PT_REGS_RET_CORE(x) BPF_CORE_READ((x), regs[31])
+#define PT_REGS_FP_CORE(x) BPF_CORE_READ((x), regs[30])
+#define PT_REGS_RC_CORE(x) BPF_CORE_READ((x), regs[2])
+#define PT_REGS_SP_CORE(x) BPF_CORE_READ((x), regs[29])
+#define PT_REGS_IP_CORE(x) BPF_CORE_READ((x), cp0_epc)
+
+#elif defined(bpf_target_powerpc)
+
+#define PT_REGS_PARM1(x) ((x)->gpr[3])
+#define PT_REGS_PARM2(x) ((x)->gpr[4])
+#define PT_REGS_PARM3(x) ((x)->gpr[5])
+#define PT_REGS_PARM4(x) ((x)->gpr[6])
+#define PT_REGS_PARM5(x) ((x)->gpr[7])
+#define PT_REGS_RC(x) ((x)->gpr[3])
+#define PT_REGS_SP(x) ((x)->sp)
+#define PT_REGS_IP(x) ((x)->nip)
+
+#define PT_REGS_PARM1_CORE(x) BPF_CORE_READ((x), gpr[3])
+#define PT_REGS_PARM2_CORE(x) BPF_CORE_READ((x), gpr[4])
+#define PT_REGS_PARM3_CORE(x) BPF_CORE_READ((x), gpr[5])
+#define PT_REGS_PARM4_CORE(x) BPF_CORE_READ((x), gpr[6])
+#define PT_REGS_PARM5_CORE(x) BPF_CORE_READ((x), gpr[7])
+#define PT_REGS_RC_CORE(x) BPF_CORE_READ((x), gpr[3])
+#define PT_REGS_SP_CORE(x) BPF_CORE_READ((x), sp)
+#define PT_REGS_IP_CORE(x) BPF_CORE_READ((x), nip)
+
+#elif defined(bpf_target_sparc)
+
+#define PT_REGS_PARM1(x) ((x)->u_regs[UREG_I0])
+#define PT_REGS_PARM2(x) ((x)->u_regs[UREG_I1])
+#define PT_REGS_PARM3(x) ((x)->u_regs[UREG_I2])
+#define PT_REGS_PARM4(x) ((x)->u_regs[UREG_I3])
+#define PT_REGS_PARM5(x) ((x)->u_regs[UREG_I4])
+#define PT_REGS_RET(x) ((x)->u_regs[UREG_I7])
+#define PT_REGS_RC(x) ((x)->u_regs[UREG_I0])
+#define PT_REGS_SP(x) ((x)->u_regs[UREG_FP])
+
+#define PT_REGS_PARM1_CORE(x) BPF_CORE_READ((x), u_regs[UREG_I0])
+#define PT_REGS_PARM2_CORE(x) BPF_CORE_READ((x), u_regs[UREG_I1])
+#define PT_REGS_PARM3_CORE(x) BPF_CORE_READ((x), u_regs[UREG_I2])
+#define PT_REGS_PARM4_CORE(x) BPF_CORE_READ((x), u_regs[UREG_I3])
+#define PT_REGS_PARM5_CORE(x) BPF_CORE_READ((x), u_regs[UREG_I4])
+#define PT_REGS_RET_CORE(x) BPF_CORE_READ((x), u_regs[UREG_I7])
+#define PT_REGS_RC_CORE(x) BPF_CORE_READ((x), u_regs[UREG_I0])
+#define PT_REGS_SP_CORE(x) BPF_CORE_READ((x), u_regs[UREG_FP])
+
+/* Should this also be a bpf_target check for the sparc case? */
+#if defined(__arch64__)
+#define PT_REGS_IP(x) ((x)->tpc)
+#define PT_REGS_IP_CORE(x) BPF_CORE_READ((x), tpc)
+#else
+#define PT_REGS_IP(x) ((x)->pc)
+#define PT_REGS_IP_CORE(x) BPF_CORE_READ((x), pc)
+#endif
+
+#elif defined(bpf_target_riscv)
+
+struct pt_regs;
+#define PT_REGS_RV const volatile struct user_regs_struct
+#define PT_REGS_PARM1(x) (((PT_REGS_RV *)(x))->a0)
+#define PT_REGS_PARM2(x) (((PT_REGS_RV *)(x))->a1)
+#define PT_REGS_PARM3(x) (((PT_REGS_RV *)(x))->a2)
+#define PT_REGS_PARM4(x) (((PT_REGS_RV *)(x))->a3)
+#define PT_REGS_PARM5(x) (((PT_REGS_RV *)(x))->a4)
+#define PT_REGS_RET(x) (((PT_REGS_RV *)(x))->ra)
+#define PT_REGS_FP(x) (((PT_REGS_RV *)(x))->s5)
+#define PT_REGS_RC(x) (((PT_REGS_RV *)(x))->a5)
+#define PT_REGS_SP(x) (((PT_REGS_RV *)(x))->sp)
+#define PT_REGS_IP(x) (((PT_REGS_RV *)(x))->epc)
+
+#define PT_REGS_PARM1_CORE(x) BPF_CORE_READ((PT_REGS_RV *)(x), a0)
+#define PT_REGS_PARM2_CORE(x) BPF_CORE_READ((PT_REGS_RV *)(x), a1)
+#define PT_REGS_PARM3_CORE(x) BPF_CORE_READ((PT_REGS_RV *)(x), a2)
+#define PT_REGS_PARM4_CORE(x) BPF_CORE_READ((PT_REGS_RV *)(x), a3)
+#define PT_REGS_PARM5_CORE(x) BPF_CORE_READ((PT_REGS_RV *)(x), a4)
+#define PT_REGS_RET_CORE(x) BPF_CORE_READ((PT_REGS_RV *)(x), ra)
+#define PT_REGS_FP_CORE(x) BPF_CORE_READ((PT_REGS_RV *)(x), fp)
+#define PT_REGS_RC_CORE(x) BPF_CORE_READ((PT_REGS_RV *)(x), a5)
+#define PT_REGS_SP_CORE(x) BPF_CORE_READ((PT_REGS_RV *)(x), sp)
+#define PT_REGS_IP_CORE(x) BPF_CORE_READ((PT_REGS_RV *)(x), epc)
+
+#endif
+
+#if defined(bpf_target_powerpc)
+#define BPF_KPROBE_READ_RET_IP(ip, ctx)		({ (ip) = (ctx)->link; })
+#define BPF_KRETPROBE_READ_RET_IP		BPF_KPROBE_READ_RET_IP
+#elif defined(bpf_target_sparc)
+#define BPF_KPROBE_READ_RET_IP(ip, ctx)		({ (ip) = PT_REGS_RET(ctx); })
+#define BPF_KRETPROBE_READ_RET_IP		BPF_KPROBE_READ_RET_IP
+#elif defined(bpf_target_defined)
+#define BPF_KPROBE_READ_RET_IP(ip, ctx)					    \
+	({ bpf_probe_read_kernel(&(ip), sizeof(ip), (void *)PT_REGS_RET(ctx)); })
+#define BPF_KRETPROBE_READ_RET_IP(ip, ctx)				    \
+	({ bpf_probe_read_kernel(&(ip), sizeof(ip),			    \
+			  (void *)(PT_REGS_FP(ctx) + sizeof(ip))); })
+#endif
+
+#if !defined(bpf_target_defined)
+
+#define PT_REGS_PARM1(x) ({ _Pragma(__BPF_TARGET_MISSING); 0l; })
+#define PT_REGS_PARM2(x) ({ _Pragma(__BPF_TARGET_MISSING); 0l; })
+#define PT_REGS_PARM3(x) ({ _Pragma(__BPF_TARGET_MISSING); 0l; })
+#define PT_REGS_PARM4(x) ({ _Pragma(__BPF_TARGET_MISSING); 0l; })
+#define PT_REGS_PARM5(x) ({ _Pragma(__BPF_TARGET_MISSING); 0l; })
+#define PT_REGS_RET(x) ({ _Pragma(__BPF_TARGET_MISSING); 0l; })
+#define PT_REGS_FP(x) ({ _Pragma(__BPF_TARGET_MISSING); 0l; })
+#define PT_REGS_RC(x) ({ _Pragma(__BPF_TARGET_MISSING); 0l; })
+#define PT_REGS_SP(x) ({ _Pragma(__BPF_TARGET_MISSING); 0l; })
+#define PT_REGS_IP(x) ({ _Pragma(__BPF_TARGET_MISSING); 0l; })
+
+#define PT_REGS_PARM1_CORE(x) ({ _Pragma(__BPF_TARGET_MISSING); 0l; })
+#define PT_REGS_PARM2_CORE(x) ({ _Pragma(__BPF_TARGET_MISSING); 0l; })
+#define PT_REGS_PARM3_CORE(x) ({ _Pragma(__BPF_TARGET_MISSING); 0l; })
+#define PT_REGS_PARM4_CORE(x) ({ _Pragma(__BPF_TARGET_MISSING); 0l; })
+#define PT_REGS_PARM5_CORE(x) ({ _Pragma(__BPF_TARGET_MISSING); 0l; })
+#define PT_REGS_RET_CORE(x) ({ _Pragma(__BPF_TARGET_MISSING); 0l; })
+#define PT_REGS_FP_CORE(x) ({ _Pragma(__BPF_TARGET_MISSING); 0l; })
+#define PT_REGS_RC_CORE(x) ({ _Pragma(__BPF_TARGET_MISSING); 0l; })
+#define PT_REGS_SP_CORE(x) ({ _Pragma(__BPF_TARGET_MISSING); 0l; })
+#define PT_REGS_IP_CORE(x) ({ _Pragma(__BPF_TARGET_MISSING); 0l; })
+
+#define BPF_KPROBE_READ_RET_IP(ip, ctx) ({ _Pragma(__BPF_TARGET_MISSING); 0l; })
+#define BPF_KRETPROBE_READ_RET_IP(ip, ctx) ({ _Pragma(__BPF_TARGET_MISSING); 0l; })
+
+#endif /* !defined(bpf_target_defined) */
+
+#ifndef ___bpf_concat
+#define ___bpf_concat(a, b) a ## b
+#endif
+#ifndef ___bpf_apply
+#define ___bpf_apply(fn, n) ___bpf_concat(fn, n)
+#endif
+#ifndef ___bpf_nth
+#define ___bpf_nth(_, _1, _2, _3, _4, _5, _6, _7, _8, _9, _a, _b, _c, N, ...) N
+#endif
+#ifndef ___bpf_narg
+#define ___bpf_narg(...) \
+	___bpf_nth(_, ##__VA_ARGS__, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+#endif
+
+#define ___bpf_ctx_cast0() ctx
+#define ___bpf_ctx_cast1(x) ___bpf_ctx_cast0(), (void *)ctx[0]
+#define ___bpf_ctx_cast2(x, args...) ___bpf_ctx_cast1(args), (void *)ctx[1]
+#define ___bpf_ctx_cast3(x, args...) ___bpf_ctx_cast2(args), (void *)ctx[2]
+#define ___bpf_ctx_cast4(x, args...) ___bpf_ctx_cast3(args), (void *)ctx[3]
+#define ___bpf_ctx_cast5(x, args...) ___bpf_ctx_cast4(args), (void *)ctx[4]
+#define ___bpf_ctx_cast6(x, args...) ___bpf_ctx_cast5(args), (void *)ctx[5]
+#define ___bpf_ctx_cast7(x, args...) ___bpf_ctx_cast6(args), (void *)ctx[6]
+#define ___bpf_ctx_cast8(x, args...) ___bpf_ctx_cast7(args), (void *)ctx[7]
+#define ___bpf_ctx_cast9(x, args...) ___bpf_ctx_cast8(args), (void *)ctx[8]
+#define ___bpf_ctx_cast10(x, args...) ___bpf_ctx_cast9(args), (void *)ctx[9]
+#define ___bpf_ctx_cast11(x, args...) ___bpf_ctx_cast10(args), (void *)ctx[10]
+#define ___bpf_ctx_cast12(x, args...) ___bpf_ctx_cast11(args), (void *)ctx[11]
+#define ___bpf_ctx_cast(args...) \
+	___bpf_apply(___bpf_ctx_cast, ___bpf_narg(args))(args)
+
+/*
+ * BPF_PROG is a convenience wrapper for generic tp_btf/fentry/fexit and
+ * similar kinds of BPF programs, that accept input arguments as a single
+ * pointer to untyped u64 array, where each u64 can actually be a typed
+ * pointer or integer of different size. Instead of requring user to write
+ * manual casts and work with array elements by index, BPF_PROG macro
+ * allows user to declare a list of named and typed input arguments in the
+ * same syntax as for normal C function. All the casting is hidden and
+ * performed transparently, while user code can just assume working with
+ * function arguments of specified type and name.
+ *
+ * Original raw context argument is preserved as well as 'ctx' argument.
+ * This is useful when using BPF helpers that expect original context
+ * as one of the parameters (e.g., for bpf_perf_event_output()).
+ */
+#define BPF_PROG(name, args...)						    \
+name(unsigned long long *ctx);						    \
+static __attribute__((always_inline)) typeof(name(0))			    \
+____##name(unsigned long long *ctx, ##args);				    \
+typeof(name(0)) name(unsigned long long *ctx)				    \
+{									    \
+	_Pragma("GCC diagnostic push")					    \
+	_Pragma("GCC diagnostic ignored \"-Wint-conversion\"")		    \
+	return ____##name(___bpf_ctx_cast(args));			    \
+	_Pragma("GCC diagnostic pop")					    \
+}									    \
+static __attribute__((always_inline)) typeof(name(0))			    \
+____##name(unsigned long long *ctx, ##args)
+
+struct pt_regs;
+
+#define ___bpf_kprobe_args0() ctx
+#define ___bpf_kprobe_args1(x) \
+	___bpf_kprobe_args0(), (void *)PT_REGS_PARM1(ctx)
+#define ___bpf_kprobe_args2(x, args...) \
+	___bpf_kprobe_args1(args), (void *)PT_REGS_PARM2(ctx)
+#define ___bpf_kprobe_args3(x, args...) \
+	___bpf_kprobe_args2(args), (void *)PT_REGS_PARM3(ctx)
+#define ___bpf_kprobe_args4(x, args...) \
+	___bpf_kprobe_args3(args), (void *)PT_REGS_PARM4(ctx)
+#define ___bpf_kprobe_args5(x, args...) \
+	___bpf_kprobe_args4(args), (void *)PT_REGS_PARM5(ctx)
+#define ___bpf_kprobe_args(args...) \
+	___bpf_apply(___bpf_kprobe_args, ___bpf_narg(args))(args)
+
+/*
+ * BPF_KPROBE serves the same purpose for kprobes as BPF_PROG for
+ * tp_btf/fentry/fexit BPF programs. It hides the underlying platform-specific
+ * low-level way of getting kprobe input arguments from struct pt_regs, and
+ * provides a familiar typed and named function arguments syntax and
+ * semantics of accessing kprobe input paremeters.
+ *
+ * Original struct pt_regs* context is preserved as 'ctx' argument. This might
+ * be necessary when using BPF helpers like bpf_perf_event_output().
+ */
+#define BPF_KPROBE(name, args...)					    \
+name(struct pt_regs *ctx);						    \
+static __attribute__((always_inline)) typeof(name(0))			    \
+____##name(struct pt_regs *ctx, ##args);				    \
+typeof(name(0)) name(struct pt_regs *ctx)				    \
+{									    \
+	_Pragma("GCC diagnostic push")					    \
+	_Pragma("GCC diagnostic ignored \"-Wint-conversion\"")		    \
+	return ____##name(___bpf_kprobe_args(args));			    \
+	_Pragma("GCC diagnostic pop")					    \
+}									    \
+static __attribute__((always_inline)) typeof(name(0))			    \
+____##name(struct pt_regs *ctx, ##args)
+
+#define ___bpf_kretprobe_args0() ctx
+#define ___bpf_kretprobe_args1(x) \
+	___bpf_kretprobe_args0(), (void *)PT_REGS_RC(ctx)
+#define ___bpf_kretprobe_args(args...) \
+	___bpf_apply(___bpf_kretprobe_args, ___bpf_narg(args))(args)
+
+/*
+ * BPF_KRETPROBE is similar to BPF_KPROBE, except, it only provides optional
+ * return value (in addition to `struct pt_regs *ctx`), but no input
+ * arguments, because they will be clobbered by the time probed function
+ * returns.
+ */
+#define BPF_KRETPROBE(name, args...)					    \
+name(struct pt_regs *ctx);						    \
+static __attribute__((always_inline)) typeof(name(0))			    \
+____##name(struct pt_regs *ctx, ##args);				    \
+typeof(name(0)) name(struct pt_regs *ctx)				    \
+{									    \
+	_Pragma("GCC diagnostic push")					    \
+	_Pragma("GCC diagnostic ignored \"-Wint-conversion\"")		    \
+	return ____##name(___bpf_kretprobe_args(args));			    \
+	_Pragma("GCC diagnostic pop")					    \
+}									    \
+static __always_inline typeof(name(0)) ____##name(struct pt_regs *ctx, ##args)
+
+#endif

--- a/internal/probe/bpf_arm64_bpfel.go
+++ b/internal/probe/bpf_arm64_bpfel.go
@@ -58,10 +58,9 @@ type bpfSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfProgramSpecs struct {
-	TracepointSchedSchedProcessExec  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exec"`
-	TracepointSchedSchedProcessExit  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
-	TracepointSchedSchedProcessFork  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_fork"`
-	TracepointSyscallsSysEnterExecve *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_execve"`
+	TracepointSchedSchedProcessExit    *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
+	TracepointSyscallsSysEnterExecve   *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_execve"`
+	TracepointBtfSchedSchedProcessFork *ebpf.ProgramSpec `ebpf:"tracepoint_btf__sched__sched_process_fork"`
 }
 
 // bpfMapSpecs contains maps before they are loaded into the kernel.
@@ -70,7 +69,6 @@ type bpfProgramSpecs struct {
 type bpfMapSpecs struct {
 	EnvPrefix             *ebpf.MapSpec `ebpf:"env_prefix"`
 	Events                *ebpf.MapSpec `ebpf:"events"`
-	RelevantForkedPids    *ebpf.MapSpec `ebpf:"relevant_forked_pids"`
 	TrackedPidsToNsPids   *ebpf.MapSpec `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.MapSpec `ebpf:"user_pid_to_container_pid"`
 }
@@ -96,7 +94,6 @@ func (o *bpfObjects) Close() error {
 type bpfMaps struct {
 	EnvPrefix             *ebpf.Map `ebpf:"env_prefix"`
 	Events                *ebpf.Map `ebpf:"events"`
-	RelevantForkedPids    *ebpf.Map `ebpf:"relevant_forked_pids"`
 	TrackedPidsToNsPids   *ebpf.Map `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.Map `ebpf:"user_pid_to_container_pid"`
 }
@@ -105,7 +102,6 @@ func (m *bpfMaps) Close() error {
 	return _BpfClose(
 		m.EnvPrefix,
 		m.Events,
-		m.RelevantForkedPids,
 		m.TrackedPidsToNsPids,
 		m.UserPidToContainerPid,
 	)
@@ -115,18 +111,16 @@ func (m *bpfMaps) Close() error {
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfPrograms struct {
-	TracepointSchedSchedProcessExec  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exec"`
-	TracepointSchedSchedProcessExit  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
-	TracepointSchedSchedProcessFork  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_fork"`
-	TracepointSyscallsSysEnterExecve *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_execve"`
+	TracepointSchedSchedProcessExit    *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
+	TracepointSyscallsSysEnterExecve   *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_execve"`
+	TracepointBtfSchedSchedProcessFork *ebpf.Program `ebpf:"tracepoint_btf__sched__sched_process_fork"`
 }
 
 func (p *bpfPrograms) Close() error {
 	return _BpfClose(
-		p.TracepointSchedSchedProcessExec,
 		p.TracepointSchedSchedProcessExit,
-		p.TracepointSchedSchedProcessFork,
 		p.TracepointSyscallsSysEnterExecve,
+		p.TracepointBtfSchedSchedProcessFork,
 	)
 }
 

--- a/internal/probe/bpf_arm64_bpfel.go
+++ b/internal/probe/bpf_arm64_bpfel.go
@@ -59,8 +59,8 @@ type bpfSpecs struct {
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfProgramSpecs struct {
 	TracepointSchedSchedProcessExit  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
+	TracepointSchedSchedProcessFork  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_fork"`
 	TracepointSyscallsSysEnterExecve *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_execve"`
-	TracepointSyscallsSysExitClone   *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_exit_clone"`
 }
 
 // bpfMapSpecs contains maps before they are loaded into the kernel.
@@ -112,15 +112,15 @@ func (m *bpfMaps) Close() error {
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfPrograms struct {
 	TracepointSchedSchedProcessExit  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
+	TracepointSchedSchedProcessFork  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_fork"`
 	TracepointSyscallsSysEnterExecve *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_execve"`
-	TracepointSyscallsSysExitClone   *ebpf.Program `ebpf:"tracepoint__syscalls__sys_exit_clone"`
 }
 
 func (p *bpfPrograms) Close() error {
 	return _BpfClose(
 		p.TracepointSchedSchedProcessExit,
+		p.TracepointSchedSchedProcessFork,
 		p.TracepointSyscallsSysEnterExecve,
-		p.TracepointSyscallsSysExitClone,
 	)
 }
 

--- a/internal/probe/bpf_arm64_bpfel.go
+++ b/internal/probe/bpf_arm64_bpfel.go
@@ -58,6 +58,7 @@ type bpfSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfProgramSpecs struct {
+	TracepointSchedSchedProcessExec  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSchedSchedProcessExit  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSchedSchedProcessFork  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_fork"`
 	TracepointSyscallsSysEnterExecve *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_execve"`
@@ -69,6 +70,7 @@ type bpfProgramSpecs struct {
 type bpfMapSpecs struct {
 	EnvPrefix             *ebpf.MapSpec `ebpf:"env_prefix"`
 	Events                *ebpf.MapSpec `ebpf:"events"`
+	RelevantForkedPids    *ebpf.MapSpec `ebpf:"relevant_forked_pids"`
 	TrackedPidsToNsPids   *ebpf.MapSpec `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.MapSpec `ebpf:"user_pid_to_container_pid"`
 }
@@ -94,6 +96,7 @@ func (o *bpfObjects) Close() error {
 type bpfMaps struct {
 	EnvPrefix             *ebpf.Map `ebpf:"env_prefix"`
 	Events                *ebpf.Map `ebpf:"events"`
+	RelevantForkedPids    *ebpf.Map `ebpf:"relevant_forked_pids"`
 	TrackedPidsToNsPids   *ebpf.Map `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.Map `ebpf:"user_pid_to_container_pid"`
 }
@@ -102,6 +105,7 @@ func (m *bpfMaps) Close() error {
 	return _BpfClose(
 		m.EnvPrefix,
 		m.Events,
+		m.RelevantForkedPids,
 		m.TrackedPidsToNsPids,
 		m.UserPidToContainerPid,
 	)
@@ -111,6 +115,7 @@ func (m *bpfMaps) Close() error {
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfPrograms struct {
+	TracepointSchedSchedProcessExec  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSchedSchedProcessExit  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSchedSchedProcessFork  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_fork"`
 	TracepointSyscallsSysEnterExecve *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_execve"`
@@ -118,6 +123,7 @@ type bpfPrograms struct {
 
 func (p *bpfPrograms) Close() error {
 	return _BpfClose(
+		p.TracepointSchedSchedProcessExec,
 		p.TracepointSchedSchedProcessExit,
 		p.TracepointSchedSchedProcessFork,
 		p.TracepointSyscallsSysEnterExecve,

--- a/internal/probe/bpf_arm64_bpfel.go
+++ b/internal/probe/bpf_arm64_bpfel.go
@@ -60,6 +60,7 @@ type bpfSpecs struct {
 type bpfProgramSpecs struct {
 	TracepointSchedSchedProcessExit  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSyscallsSysEnterExecve *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_execve"`
+	TracepointSyscallsSysExitClone   *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_exit_clone"`
 }
 
 // bpfMapSpecs contains maps before they are loaded into the kernel.
@@ -112,12 +113,14 @@ func (m *bpfMaps) Close() error {
 type bpfPrograms struct {
 	TracepointSchedSchedProcessExit  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSyscallsSysEnterExecve *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_execve"`
+	TracepointSyscallsSysExitClone   *ebpf.Program `ebpf:"tracepoint__syscalls__sys_exit_clone"`
 }
 
 func (p *bpfPrograms) Close() error {
 	return _BpfClose(
 		p.TracepointSchedSchedProcessExit,
 		p.TracepointSyscallsSysEnterExecve,
+		p.TracepointSyscallsSysExitClone,
 	)
 }
 

--- a/internal/probe/bpf_no_btf_arm64_bpfel.go
+++ b/internal/probe/bpf_no_btf_arm64_bpfel.go
@@ -59,8 +59,8 @@ type bpf_no_btfSpecs struct {
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpf_no_btfProgramSpecs struct {
 	TracepointSchedSchedProcessExit  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
+	TracepointSchedSchedProcessFork  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_fork"`
 	TracepointSyscallsSysEnterExecve *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_execve"`
-	TracepointSyscallsSysExitClone   *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_exit_clone"`
 }
 
 // bpf_no_btfMapSpecs contains maps before they are loaded into the kernel.
@@ -112,15 +112,15 @@ func (m *bpf_no_btfMaps) Close() error {
 // It can be passed to loadBpf_no_btfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpf_no_btfPrograms struct {
 	TracepointSchedSchedProcessExit  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
+	TracepointSchedSchedProcessFork  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_fork"`
 	TracepointSyscallsSysEnterExecve *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_execve"`
-	TracepointSyscallsSysExitClone   *ebpf.Program `ebpf:"tracepoint__syscalls__sys_exit_clone"`
 }
 
 func (p *bpf_no_btfPrograms) Close() error {
 	return _Bpf_no_btfClose(
 		p.TracepointSchedSchedProcessExit,
+		p.TracepointSchedSchedProcessFork,
 		p.TracepointSyscallsSysEnterExecve,
-		p.TracepointSyscallsSysExitClone,
 	)
 }
 

--- a/internal/probe/bpf_no_btf_arm64_bpfel.go
+++ b/internal/probe/bpf_no_btf_arm64_bpfel.go
@@ -58,7 +58,6 @@ type bpf_no_btfSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpf_no_btfProgramSpecs struct {
-	TracepointSchedSchedProcessExec  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSchedSchedProcessExit  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSchedSchedProcessFork  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_fork"`
 	TracepointSyscallsSysEnterExecve *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_execve"`
@@ -70,7 +69,6 @@ type bpf_no_btfProgramSpecs struct {
 type bpf_no_btfMapSpecs struct {
 	EnvPrefix             *ebpf.MapSpec `ebpf:"env_prefix"`
 	Events                *ebpf.MapSpec `ebpf:"events"`
-	RelevantForkedPids    *ebpf.MapSpec `ebpf:"relevant_forked_pids"`
 	TrackedPidsToNsPids   *ebpf.MapSpec `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.MapSpec `ebpf:"user_pid_to_container_pid"`
 }
@@ -96,7 +94,6 @@ func (o *bpf_no_btfObjects) Close() error {
 type bpf_no_btfMaps struct {
 	EnvPrefix             *ebpf.Map `ebpf:"env_prefix"`
 	Events                *ebpf.Map `ebpf:"events"`
-	RelevantForkedPids    *ebpf.Map `ebpf:"relevant_forked_pids"`
 	TrackedPidsToNsPids   *ebpf.Map `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.Map `ebpf:"user_pid_to_container_pid"`
 }
@@ -105,7 +102,6 @@ func (m *bpf_no_btfMaps) Close() error {
 	return _Bpf_no_btfClose(
 		m.EnvPrefix,
 		m.Events,
-		m.RelevantForkedPids,
 		m.TrackedPidsToNsPids,
 		m.UserPidToContainerPid,
 	)
@@ -115,7 +111,6 @@ func (m *bpf_no_btfMaps) Close() error {
 //
 // It can be passed to loadBpf_no_btfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpf_no_btfPrograms struct {
-	TracepointSchedSchedProcessExec  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSchedSchedProcessExit  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSchedSchedProcessFork  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_fork"`
 	TracepointSyscallsSysEnterExecve *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_execve"`
@@ -123,7 +118,6 @@ type bpf_no_btfPrograms struct {
 
 func (p *bpf_no_btfPrograms) Close() error {
 	return _Bpf_no_btfClose(
-		p.TracepointSchedSchedProcessExec,
 		p.TracepointSchedSchedProcessExit,
 		p.TracepointSchedSchedProcessFork,
 		p.TracepointSyscallsSysEnterExecve,

--- a/internal/probe/bpf_no_btf_arm64_bpfel.go
+++ b/internal/probe/bpf_no_btf_arm64_bpfel.go
@@ -58,6 +58,7 @@ type bpf_no_btfSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpf_no_btfProgramSpecs struct {
+	TracepointSchedSchedProcessExec  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSchedSchedProcessExit  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSchedSchedProcessFork  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_fork"`
 	TracepointSyscallsSysEnterExecve *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_execve"`
@@ -69,6 +70,7 @@ type bpf_no_btfProgramSpecs struct {
 type bpf_no_btfMapSpecs struct {
 	EnvPrefix             *ebpf.MapSpec `ebpf:"env_prefix"`
 	Events                *ebpf.MapSpec `ebpf:"events"`
+	RelevantForkedPids    *ebpf.MapSpec `ebpf:"relevant_forked_pids"`
 	TrackedPidsToNsPids   *ebpf.MapSpec `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.MapSpec `ebpf:"user_pid_to_container_pid"`
 }
@@ -94,6 +96,7 @@ func (o *bpf_no_btfObjects) Close() error {
 type bpf_no_btfMaps struct {
 	EnvPrefix             *ebpf.Map `ebpf:"env_prefix"`
 	Events                *ebpf.Map `ebpf:"events"`
+	RelevantForkedPids    *ebpf.Map `ebpf:"relevant_forked_pids"`
 	TrackedPidsToNsPids   *ebpf.Map `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.Map `ebpf:"user_pid_to_container_pid"`
 }
@@ -102,6 +105,7 @@ func (m *bpf_no_btfMaps) Close() error {
 	return _Bpf_no_btfClose(
 		m.EnvPrefix,
 		m.Events,
+		m.RelevantForkedPids,
 		m.TrackedPidsToNsPids,
 		m.UserPidToContainerPid,
 	)
@@ -111,6 +115,7 @@ func (m *bpf_no_btfMaps) Close() error {
 //
 // It can be passed to loadBpf_no_btfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpf_no_btfPrograms struct {
+	TracepointSchedSchedProcessExec  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSchedSchedProcessExit  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSchedSchedProcessFork  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_fork"`
 	TracepointSyscallsSysEnterExecve *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_execve"`
@@ -118,6 +123,7 @@ type bpf_no_btfPrograms struct {
 
 func (p *bpf_no_btfPrograms) Close() error {
 	return _Bpf_no_btfClose(
+		p.TracepointSchedSchedProcessExec,
 		p.TracepointSchedSchedProcessExit,
 		p.TracepointSchedSchedProcessFork,
 		p.TracepointSyscallsSysEnterExecve,

--- a/internal/probe/bpf_no_btf_arm64_bpfel.go
+++ b/internal/probe/bpf_no_btf_arm64_bpfel.go
@@ -60,6 +60,7 @@ type bpf_no_btfSpecs struct {
 type bpf_no_btfProgramSpecs struct {
 	TracepointSchedSchedProcessExit  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSyscallsSysEnterExecve *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_execve"`
+	TracepointSyscallsSysExitClone   *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_exit_clone"`
 }
 
 // bpf_no_btfMapSpecs contains maps before they are loaded into the kernel.
@@ -112,12 +113,14 @@ func (m *bpf_no_btfMaps) Close() error {
 type bpf_no_btfPrograms struct {
 	TracepointSchedSchedProcessExit  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSyscallsSysEnterExecve *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_execve"`
+	TracepointSyscallsSysExitClone   *ebpf.Program `ebpf:"tracepoint__syscalls__sys_exit_clone"`
 }
 
 func (p *bpf_no_btfPrograms) Close() error {
 	return _Bpf_no_btfClose(
 		p.TracepointSchedSchedProcessExit,
 		p.TracepointSyscallsSysEnterExecve,
+		p.TracepointSyscallsSysExitClone,
 	)
 }
 

--- a/internal/probe/bpf_no_btf_x86_bpfel.go
+++ b/internal/probe/bpf_no_btf_x86_bpfel.go
@@ -59,8 +59,8 @@ type bpf_no_btfSpecs struct {
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpf_no_btfProgramSpecs struct {
 	TracepointSchedSchedProcessExit  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
+	TracepointSchedSchedProcessFork  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_fork"`
 	TracepointSyscallsSysEnterExecve *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_execve"`
-	TracepointSyscallsSysExitClone   *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_exit_clone"`
 }
 
 // bpf_no_btfMapSpecs contains maps before they are loaded into the kernel.
@@ -112,15 +112,15 @@ func (m *bpf_no_btfMaps) Close() error {
 // It can be passed to loadBpf_no_btfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpf_no_btfPrograms struct {
 	TracepointSchedSchedProcessExit  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
+	TracepointSchedSchedProcessFork  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_fork"`
 	TracepointSyscallsSysEnterExecve *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_execve"`
-	TracepointSyscallsSysExitClone   *ebpf.Program `ebpf:"tracepoint__syscalls__sys_exit_clone"`
 }
 
 func (p *bpf_no_btfPrograms) Close() error {
 	return _Bpf_no_btfClose(
 		p.TracepointSchedSchedProcessExit,
+		p.TracepointSchedSchedProcessFork,
 		p.TracepointSyscallsSysEnterExecve,
-		p.TracepointSyscallsSysExitClone,
 	)
 }
 

--- a/internal/probe/bpf_no_btf_x86_bpfel.go
+++ b/internal/probe/bpf_no_btf_x86_bpfel.go
@@ -58,7 +58,6 @@ type bpf_no_btfSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpf_no_btfProgramSpecs struct {
-	TracepointSchedSchedProcessExec  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSchedSchedProcessExit  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSchedSchedProcessFork  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_fork"`
 	TracepointSyscallsSysEnterExecve *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_execve"`
@@ -70,7 +69,6 @@ type bpf_no_btfProgramSpecs struct {
 type bpf_no_btfMapSpecs struct {
 	EnvPrefix             *ebpf.MapSpec `ebpf:"env_prefix"`
 	Events                *ebpf.MapSpec `ebpf:"events"`
-	RelevantForkedPids    *ebpf.MapSpec `ebpf:"relevant_forked_pids"`
 	TrackedPidsToNsPids   *ebpf.MapSpec `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.MapSpec `ebpf:"user_pid_to_container_pid"`
 }
@@ -96,7 +94,6 @@ func (o *bpf_no_btfObjects) Close() error {
 type bpf_no_btfMaps struct {
 	EnvPrefix             *ebpf.Map `ebpf:"env_prefix"`
 	Events                *ebpf.Map `ebpf:"events"`
-	RelevantForkedPids    *ebpf.Map `ebpf:"relevant_forked_pids"`
 	TrackedPidsToNsPids   *ebpf.Map `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.Map `ebpf:"user_pid_to_container_pid"`
 }
@@ -105,7 +102,6 @@ func (m *bpf_no_btfMaps) Close() error {
 	return _Bpf_no_btfClose(
 		m.EnvPrefix,
 		m.Events,
-		m.RelevantForkedPids,
 		m.TrackedPidsToNsPids,
 		m.UserPidToContainerPid,
 	)
@@ -115,7 +111,6 @@ func (m *bpf_no_btfMaps) Close() error {
 //
 // It can be passed to loadBpf_no_btfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpf_no_btfPrograms struct {
-	TracepointSchedSchedProcessExec  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSchedSchedProcessExit  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSchedSchedProcessFork  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_fork"`
 	TracepointSyscallsSysEnterExecve *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_execve"`
@@ -123,7 +118,6 @@ type bpf_no_btfPrograms struct {
 
 func (p *bpf_no_btfPrograms) Close() error {
 	return _Bpf_no_btfClose(
-		p.TracepointSchedSchedProcessExec,
 		p.TracepointSchedSchedProcessExit,
 		p.TracepointSchedSchedProcessFork,
 		p.TracepointSyscallsSysEnterExecve,

--- a/internal/probe/bpf_no_btf_x86_bpfel.go
+++ b/internal/probe/bpf_no_btf_x86_bpfel.go
@@ -58,6 +58,7 @@ type bpf_no_btfSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpf_no_btfProgramSpecs struct {
+	TracepointSchedSchedProcessExec  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSchedSchedProcessExit  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSchedSchedProcessFork  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_fork"`
 	TracepointSyscallsSysEnterExecve *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_execve"`
@@ -69,6 +70,7 @@ type bpf_no_btfProgramSpecs struct {
 type bpf_no_btfMapSpecs struct {
 	EnvPrefix             *ebpf.MapSpec `ebpf:"env_prefix"`
 	Events                *ebpf.MapSpec `ebpf:"events"`
+	RelevantForkedPids    *ebpf.MapSpec `ebpf:"relevant_forked_pids"`
 	TrackedPidsToNsPids   *ebpf.MapSpec `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.MapSpec `ebpf:"user_pid_to_container_pid"`
 }
@@ -94,6 +96,7 @@ func (o *bpf_no_btfObjects) Close() error {
 type bpf_no_btfMaps struct {
 	EnvPrefix             *ebpf.Map `ebpf:"env_prefix"`
 	Events                *ebpf.Map `ebpf:"events"`
+	RelevantForkedPids    *ebpf.Map `ebpf:"relevant_forked_pids"`
 	TrackedPidsToNsPids   *ebpf.Map `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.Map `ebpf:"user_pid_to_container_pid"`
 }
@@ -102,6 +105,7 @@ func (m *bpf_no_btfMaps) Close() error {
 	return _Bpf_no_btfClose(
 		m.EnvPrefix,
 		m.Events,
+		m.RelevantForkedPids,
 		m.TrackedPidsToNsPids,
 		m.UserPidToContainerPid,
 	)
@@ -111,6 +115,7 @@ func (m *bpf_no_btfMaps) Close() error {
 //
 // It can be passed to loadBpf_no_btfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpf_no_btfPrograms struct {
+	TracepointSchedSchedProcessExec  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSchedSchedProcessExit  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSchedSchedProcessFork  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_fork"`
 	TracepointSyscallsSysEnterExecve *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_execve"`
@@ -118,6 +123,7 @@ type bpf_no_btfPrograms struct {
 
 func (p *bpf_no_btfPrograms) Close() error {
 	return _Bpf_no_btfClose(
+		p.TracepointSchedSchedProcessExec,
 		p.TracepointSchedSchedProcessExit,
 		p.TracepointSchedSchedProcessFork,
 		p.TracepointSyscallsSysEnterExecve,

--- a/internal/probe/bpf_no_btf_x86_bpfel.go
+++ b/internal/probe/bpf_no_btf_x86_bpfel.go
@@ -60,6 +60,7 @@ type bpf_no_btfSpecs struct {
 type bpf_no_btfProgramSpecs struct {
 	TracepointSchedSchedProcessExit  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSyscallsSysEnterExecve *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_execve"`
+	TracepointSyscallsSysExitClone   *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_exit_clone"`
 }
 
 // bpf_no_btfMapSpecs contains maps before they are loaded into the kernel.
@@ -112,12 +113,14 @@ func (m *bpf_no_btfMaps) Close() error {
 type bpf_no_btfPrograms struct {
 	TracepointSchedSchedProcessExit  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSyscallsSysEnterExecve *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_execve"`
+	TracepointSyscallsSysExitClone   *ebpf.Program `ebpf:"tracepoint__syscalls__sys_exit_clone"`
 }
 
 func (p *bpf_no_btfPrograms) Close() error {
 	return _Bpf_no_btfClose(
 		p.TracepointSchedSchedProcessExit,
 		p.TracepointSyscallsSysEnterExecve,
+		p.TracepointSyscallsSysExitClone,
 	)
 }
 

--- a/internal/probe/bpf_x86_bpfel.go
+++ b/internal/probe/bpf_x86_bpfel.go
@@ -58,10 +58,9 @@ type bpfSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfProgramSpecs struct {
-	TracepointSchedSchedProcessExec  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exec"`
-	TracepointSchedSchedProcessExit  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
-	TracepointSchedSchedProcessFork  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_fork"`
-	TracepointSyscallsSysEnterExecve *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_execve"`
+	TracepointSchedSchedProcessExit    *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
+	TracepointSyscallsSysEnterExecve   *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_execve"`
+	TracepointBtfSchedSchedProcessFork *ebpf.ProgramSpec `ebpf:"tracepoint_btf__sched__sched_process_fork"`
 }
 
 // bpfMapSpecs contains maps before they are loaded into the kernel.
@@ -70,7 +69,6 @@ type bpfProgramSpecs struct {
 type bpfMapSpecs struct {
 	EnvPrefix             *ebpf.MapSpec `ebpf:"env_prefix"`
 	Events                *ebpf.MapSpec `ebpf:"events"`
-	RelevantForkedPids    *ebpf.MapSpec `ebpf:"relevant_forked_pids"`
 	TrackedPidsToNsPids   *ebpf.MapSpec `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.MapSpec `ebpf:"user_pid_to_container_pid"`
 }
@@ -96,7 +94,6 @@ func (o *bpfObjects) Close() error {
 type bpfMaps struct {
 	EnvPrefix             *ebpf.Map `ebpf:"env_prefix"`
 	Events                *ebpf.Map `ebpf:"events"`
-	RelevantForkedPids    *ebpf.Map `ebpf:"relevant_forked_pids"`
 	TrackedPidsToNsPids   *ebpf.Map `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.Map `ebpf:"user_pid_to_container_pid"`
 }
@@ -105,7 +102,6 @@ func (m *bpfMaps) Close() error {
 	return _BpfClose(
 		m.EnvPrefix,
 		m.Events,
-		m.RelevantForkedPids,
 		m.TrackedPidsToNsPids,
 		m.UserPidToContainerPid,
 	)
@@ -115,18 +111,16 @@ func (m *bpfMaps) Close() error {
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfPrograms struct {
-	TracepointSchedSchedProcessExec  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exec"`
-	TracepointSchedSchedProcessExit  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
-	TracepointSchedSchedProcessFork  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_fork"`
-	TracepointSyscallsSysEnterExecve *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_execve"`
+	TracepointSchedSchedProcessExit    *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
+	TracepointSyscallsSysEnterExecve   *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_execve"`
+	TracepointBtfSchedSchedProcessFork *ebpf.Program `ebpf:"tracepoint_btf__sched__sched_process_fork"`
 }
 
 func (p *bpfPrograms) Close() error {
 	return _BpfClose(
-		p.TracepointSchedSchedProcessExec,
 		p.TracepointSchedSchedProcessExit,
-		p.TracepointSchedSchedProcessFork,
 		p.TracepointSyscallsSysEnterExecve,
+		p.TracepointBtfSchedSchedProcessFork,
 	)
 }
 

--- a/internal/probe/bpf_x86_bpfel.go
+++ b/internal/probe/bpf_x86_bpfel.go
@@ -59,8 +59,8 @@ type bpfSpecs struct {
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfProgramSpecs struct {
 	TracepointSchedSchedProcessExit  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
+	TracepointSchedSchedProcessFork  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_fork"`
 	TracepointSyscallsSysEnterExecve *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_execve"`
-	TracepointSyscallsSysExitClone   *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_exit_clone"`
 }
 
 // bpfMapSpecs contains maps before they are loaded into the kernel.
@@ -112,15 +112,15 @@ func (m *bpfMaps) Close() error {
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfPrograms struct {
 	TracepointSchedSchedProcessExit  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
+	TracepointSchedSchedProcessFork  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_fork"`
 	TracepointSyscallsSysEnterExecve *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_execve"`
-	TracepointSyscallsSysExitClone   *ebpf.Program `ebpf:"tracepoint__syscalls__sys_exit_clone"`
 }
 
 func (p *bpfPrograms) Close() error {
 	return _BpfClose(
 		p.TracepointSchedSchedProcessExit,
+		p.TracepointSchedSchedProcessFork,
 		p.TracepointSyscallsSysEnterExecve,
-		p.TracepointSyscallsSysExitClone,
 	)
 }
 

--- a/internal/probe/bpf_x86_bpfel.go
+++ b/internal/probe/bpf_x86_bpfel.go
@@ -58,6 +58,7 @@ type bpfSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfProgramSpecs struct {
+	TracepointSchedSchedProcessExec  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSchedSchedProcessExit  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSchedSchedProcessFork  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_fork"`
 	TracepointSyscallsSysEnterExecve *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_execve"`
@@ -69,6 +70,7 @@ type bpfProgramSpecs struct {
 type bpfMapSpecs struct {
 	EnvPrefix             *ebpf.MapSpec `ebpf:"env_prefix"`
 	Events                *ebpf.MapSpec `ebpf:"events"`
+	RelevantForkedPids    *ebpf.MapSpec `ebpf:"relevant_forked_pids"`
 	TrackedPidsToNsPids   *ebpf.MapSpec `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.MapSpec `ebpf:"user_pid_to_container_pid"`
 }
@@ -94,6 +96,7 @@ func (o *bpfObjects) Close() error {
 type bpfMaps struct {
 	EnvPrefix             *ebpf.Map `ebpf:"env_prefix"`
 	Events                *ebpf.Map `ebpf:"events"`
+	RelevantForkedPids    *ebpf.Map `ebpf:"relevant_forked_pids"`
 	TrackedPidsToNsPids   *ebpf.Map `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.Map `ebpf:"user_pid_to_container_pid"`
 }
@@ -102,6 +105,7 @@ func (m *bpfMaps) Close() error {
 	return _BpfClose(
 		m.EnvPrefix,
 		m.Events,
+		m.RelevantForkedPids,
 		m.TrackedPidsToNsPids,
 		m.UserPidToContainerPid,
 	)
@@ -111,6 +115,7 @@ func (m *bpfMaps) Close() error {
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfPrograms struct {
+	TracepointSchedSchedProcessExec  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSchedSchedProcessExit  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSchedSchedProcessFork  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_fork"`
 	TracepointSyscallsSysEnterExecve *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_execve"`
@@ -118,6 +123,7 @@ type bpfPrograms struct {
 
 func (p *bpfPrograms) Close() error {
 	return _BpfClose(
+		p.TracepointSchedSchedProcessExec,
 		p.TracepointSchedSchedProcessExit,
 		p.TracepointSchedSchedProcessFork,
 		p.TracepointSyscallsSysEnterExecve,

--- a/internal/probe/bpf_x86_bpfel.go
+++ b/internal/probe/bpf_x86_bpfel.go
@@ -60,6 +60,7 @@ type bpfSpecs struct {
 type bpfProgramSpecs struct {
 	TracepointSchedSchedProcessExit  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSyscallsSysEnterExecve *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_execve"`
+	TracepointSyscallsSysExitClone   *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_exit_clone"`
 }
 
 // bpfMapSpecs contains maps before they are loaded into the kernel.
@@ -112,12 +113,14 @@ func (m *bpfMaps) Close() error {
 type bpfPrograms struct {
 	TracepointSchedSchedProcessExit  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSyscallsSysEnterExecve *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_execve"`
+	TracepointSyscallsSysExitClone   *ebpf.Program `ebpf:"tracepoint__syscalls__sys_exit_clone"`
 }
 
 func (p *bpfPrograms) Close() error {
 	return _BpfClose(
 		p.TracepointSchedSchedProcessExit,
 		p.TracepointSyscallsSysEnterExecve,
+		p.TracepointSyscallsSysExitClone,
 	)
 }
 

--- a/internal/probe/ebpf/detector.bpf.c
+++ b/internal/probe/ebpf/detector.bpf.c
@@ -178,7 +178,7 @@ int tracepoint__syscalls__sys_enter_execve(struct syscall_trace_enter* ctx) {
             found_relevant = true;
             break;
         }
-	}
+    }
 
     if (!found_relevant) {
         return 0;

--- a/internal/probe/ebpf/detector.bpf.c
+++ b/internal/probe/ebpf/detector.bpf.c
@@ -41,6 +41,13 @@ struct {
 	__uint(max_entries, MAX_CONCURRENT_PIDS);
 } tracked_pids_to_ns_pids SEC(".maps");
 
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, u32);   // the pid created with a fork variant
+	__type(value, u8); // not used
+	__uint(max_entries, MAX_CONCURRENT_PIDS);
+} relevant_forked_pids SEC(".maps");
+
 // The following map is used to store the mapping between the PID in the configured namespace
 // (which the user is aware of) and the PID in the last level namespace (the container PID).
 // It can be read from user-space.
@@ -233,21 +240,15 @@ int tracepoint__sched__sched_process_fork(struct trace_event_raw_sched_process_f
         return 0;
     }
 
-    pids_in_ns_t pids = {0};
+    bpf_printk("clone/fork: parent_pid: %d, child_pid: %d, configured_ns_pid: %d, last_level_pid: %d\n", parent_pid, child_pid);
 
-#ifdef NO_BTF
-    pids.configured_ns_pid = child_pid;
-    pids.last_level_pid = 0;
-#else
-    struct task_struct *task = (struct task_struct *)bpf_get_current_task();
-    ret_code = get_pid_for_configured_ns(task, &pids);
-    if (ret_code < 0) {
-        bpf_printk("Could not find PID for task: 0x%llx", bpf_get_current_pid_tgid());
+    // store the child pid in the map
+    u8 dummy_value = 0;
+    ret_code = bpf_map_update_elem(&relevant_forked_pids, &child_pid, &dummy_value, BPF_ANY);
+    if (ret_code != 0) {
+        bpf_printk("Failed to update relevant forked PIDs map: %d", ret_code);
         return 0;
     }
-#endif
-
-    bpf_printk("clone/fork: parent_pid: %d, child_pid: %d, configured_ns_pid: %d, last_level_pid: %d\n", parent_pid, child_pid, pids.configured_ns_pid, pids.last_level_pid);
 
     // process_event_t event = {
     //     // TODO: should we tell the user space that this was a result of clone/fork/exec? or just tell its a new process
@@ -256,6 +257,36 @@ int tracepoint__sched__sched_process_fork(struct trace_event_raw_sched_process_f
     // };
 
     // bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event, sizeof(event));
+    return 0;
+}
+
+SEC("tracepoint/sched/sched_process_exec")
+int tracepoint__sched__sched_process_exec(struct trace_event_raw_sched_process_exec* ctx) {
+    u32 pid = (u32)(ctx->pid);
+    u32 old_pid = (u32)(ctx->old_pid);
+
+    long ret_code = 0;
+    void *found = NULL;
+    found = bpf_map_lookup_elem(&relevant_forked_pids, &pid);
+    if (found != NULL) {
+        bpf_printk("process_exec found buy pid forked: pid: %d, old_pid: %d\n", pid, old_pid);
+        ret_code = bpf_map_delete_elem(&relevant_forked_pids, &pid);
+        if (ret_code != 0) {
+            bpf_printk("Failed to delete relevant forked PIDs map: %d", ret_code);
+        }
+        return 0;
+    }
+
+    found = bpf_map_lookup_elem(&relevant_forked_pids, &old_pid);
+    if (found != NULL) {
+        bpf_printk("process_exec found buy old_pid forked: pid: %d, old_pid: %d\n", pid, old_pid);
+        ret_code = bpf_map_delete_elem(&relevant_forked_pids, &old_pid);
+        if (ret_code != 0) {
+            bpf_printk("Failed to delete relevant forked PIDs map: %d", ret_code);
+        }
+        return 0;
+    }
+
     return 0;
 }
 

--- a/internal/probe/ebpf/detector.bpf.c
+++ b/internal/probe/ebpf/detector.bpf.c
@@ -3,6 +3,7 @@
 
 #ifndef NO_BTF
 #include "bpf_core_read.h"
+#include "bpf_tracing.h"
 #endif
 
 char __license[] SEC("license") = "Dual MIT/GPL";
@@ -221,8 +222,8 @@ int tracepoint__syscalls__sys_enter_execve(struct syscall_trace_enter* ctx) {
 }
 
 #ifndef NO_BTF
-SEC("tp_btf/sched/sched_process_fork")
-int tracepoint_btf__sched__sched_process_fork(struct task_struct *parent, struct task_struct *child) {
+SEC("tp_btf/sched_process_fork")
+int BPF_PROG(tracepoint_btf__sched__sched_process_fork, struct task_struct *parent, struct task_struct *child) {
     long ret_code = 0; 
 
     u32 parent_pid = (u32)BPF_CORE_READ(parent, pid);

--- a/internal/probe/ebpf/detector.bpf.c
+++ b/internal/probe/ebpf/detector.bpf.c
@@ -222,7 +222,7 @@ int tracepoint__syscalls__sys_enter_execve(struct syscall_trace_enter* ctx) {
 }
 
 #ifndef NO_BTF
-SEC("tp_btf/sched_process_fork")
+SEC("raw_tp/sched_process_fork")
 int BPF_PROG(tracepoint_btf__sched__sched_process_fork, struct task_struct *parent, struct task_struct *child) {
     long ret_code = 0; 
 

--- a/internal/probe/ebpf/detector.bpf.c
+++ b/internal/probe/ebpf/detector.bpf.c
@@ -220,6 +220,49 @@ int tracepoint__syscalls__sys_enter_execve(struct syscall_trace_enter* ctx) {
     return 0;
 }
 
+SEC("tracepoint/syscalls/sys_exit_clone")
+int tracepoint__syscalls__sys_exit_clone(struct syscall_trace_exit* ctx) {
+    long ret_code = 0; 
+
+    // the returned pid is the pid of the new process (from the kernel perspective)
+    u32 returned_pid = (u32)ctx->ret;
+    if (returned_pid == 0) {
+        return 0;
+    }
+
+    // assume that this clone/fork is called from a process we are tracking (went through execve)
+    u32 caller_pid = (u32)(bpf_get_current_pid_tgid() & 0xFFFFFFFF);
+    u32 *tracked_pid = bpf_map_lookup_elem(&tracked_pids_to_ns_pids, &caller_pid);
+    if (tracked_pid == NULL) {
+        return 0;
+    }
+
+    pids_in_ns_t pids = {0};
+
+#ifdef NO_BTF
+    pids.configured_ns_pid = returned_pid;
+    pids.last_level_pid = 0;
+#else
+    struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+    ret_code = get_pid_for_configured_ns(task, &pids);
+    if (ret_code < 0) {
+        bpf_printk("Could not find PID for task: 0x%llx", bpf_get_current_pid_tgid());
+        return 0;
+    }
+#endif
+
+    bpf_printk("clone/fork: caller_pid: %d, returned_pid: %d, configured_ns_pid: %d, last_level_pid: %d\n", caller_pid, returned_pid, pids.configured_ns_pid, pids.last_level_pid);
+
+    // process_event_t event = {
+    //     // TODO: should we tell the user space that this was a result of clone/fork/exec? or just tell its a new process
+    //     .type = PROCESS_EXEC,
+    //     .pid = pids.configured_ns_pid,
+    // };
+
+    // bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event, sizeof(event));
+    return 0;
+}
+
 SEC("tracepoint/sched/sched_process_exit")
 int tracepoint__sched__sched_process_exit(struct trace_event_raw_sched_process_exec* ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();

--- a/internal/probe/ebpf/detector.bpf.c
+++ b/internal/probe/ebpf/detector.bpf.c
@@ -230,6 +230,14 @@ SEC("raw_tp/sched_process_fork")
 int BPF_PROG(tracepoint_btf__sched__sched_process_fork, struct task_struct *parent, struct task_struct *child) {
     long ret_code = 0; 
 
+    u32 parent_tgid = (u32)BPF_CORE_READ(parent, tgid);
+    u32 child_tgid = (u32)BPF_CORE_READ(child, tgid);
+
+    if (parent_tgid == child_tgid) {
+        // this is a thread, not a process
+        return 0;
+    }
+
     u32 parent_pid = (u32)BPF_CORE_READ(parent, pid);
     u32 child_pid = (u32)BPF_CORE_READ(child, pid);
 

--- a/internal/probe/ebpf/detector.bpf.c
+++ b/internal/probe/ebpf/detector.bpf.c
@@ -242,7 +242,7 @@ int BPF_PROG(tracepoint_btf__sched__sched_process_fork, struct task_struct *pare
     u32 child_pid = (u32)BPF_CORE_READ(child, pid);
 
     // filter only relevant pids based on the parent
-    // check if that this clone/fork is called from a process we are tracking (went through execve)
+    // check if that this clone/fork is called from a process we are tracking
     void *found = bpf_map_lookup_elem(&tracked_pids_to_ns_pids, &parent_pid);
     if (found == NULL) {
         return 0;
@@ -284,6 +284,9 @@ int tracepoint__sched__sched_process_fork(struct trace_event_raw_sched_process_f
     long ret_code = 0;
     u32 parent_pid = (u32)ctx->parent_pid;
     u32 child_pid = (u32)ctx->child_pid;
+
+    // TODO: check if this is a thread or a process. without BTF this is not straightforward
+    // we could read /proc/<pid>/status in user space to verify we only pass events on processes (tgid == pid)
 
     // check if that this clone/fork is called from a process we are tracking (went through execve)
     void *found = bpf_map_lookup_elem(&tracked_pids_to_ns_pids, &parent_pid);

--- a/internal/probe/ebpf/detector.bpf.c
+++ b/internal/probe/ebpf/detector.bpf.c
@@ -286,14 +286,14 @@ int tracepoint__sched__sched_process_fork(struct trace_event_raw_sched_process_f
     u32 parent_pid = (u32)ctx->parent_pid;
     u32 child_pid = (u32)ctx->child_pid;
 
-    // TODO: check if this is a thread or a process. without BTF this is not straightforward
-    // we could read /proc/<pid>/status in user space to verify we only pass events on processes (tgid == pid)
-
     // check if that this clone/fork is called from a process we are tracking (went through execve)
     void *found = bpf_map_lookup_elem(&tracked_pids_to_ns_pids, &parent_pid);
     if (found == NULL) {
         return 0;
     }
+
+    // we can't make sure here that the child pid is a new process, and not a thread.
+    // this will be verified in user space (only when BTF is not available)
 
     u32 unknown_pid = 0;
     ret_code = bpf_map_update_elem(&tracked_pids_to_ns_pids, &child_pid, &child_pid, BPF_ANY);

--- a/internal/probe/probe.go
+++ b/internal/probe/probe.go
@@ -318,20 +318,12 @@ LOOP:
 			case common.EventTypeFork:
 				if !p.btfDisabled {
 					// BTF is enabled, we can trust the event is a relevant process being created
-
-					// TODO: remove this log
-					p.logger.Info("BTF enabled. process fork event", "pid", event.Pid)
 					p.consumer.Add(int(event.Pid))
 				} else {
 					// BTF is disabled, we need to check if the PID is a process or thread
 					isProcess, err := proc.IsProcess(int(event.Pid))
 					if err == nil && isProcess {
-						// TODO: remove this log
-						p.logger.Info("BTF disabled. process fork event", "pid", event.Pid)
 						p.consumer.Add(int(event.Pid))
-					} else {
-						// TODO: remove this log
-						p.logger.Info("BTF disabled. thread fork event", "pid", event.Pid)
 					}
 				}
 			case common.EventTypeExit:

--- a/internal/probe/probe.go
+++ b/internal/probe/probe.go
@@ -42,6 +42,7 @@ const (
 
 	eventsMapName            = "events"
 	processExecProgramName   = "tracepoint__syscalls__sys_enter_execve"
+	processCloneProgramName  = "tracepoint__syscalls__sys_exit_clone"
 	processExitProgramName   = "tracepoint__sched__sched_process_exit"
 	pidToContainerPIDMapName = "user_pid_to_container_pid"
 	envPrefixMapName         = "env_prefix"
@@ -183,6 +184,12 @@ func (p *Probe) attach() error {
 	l, err = link.Tracepoint("sched", "sched_process_exit", p.c.Programs[processExitProgramName], nil)
 	if err != nil {
 		return fmt.Errorf("can't attach probe sched_process_exit: %w", err)
+	}
+	p.links = append(p.links, l)
+
+	l, err = link.Tracepoint("syscalls", "sys_exit_clone", p.c.Programs[processCloneProgramName], nil)
+	if err != nil {
+		return fmt.Errorf("can't attach probe sys_exit_clone: %w", err)
 	}
 	p.links = append(p.links, l)
 

--- a/internal/probe/probe.go
+++ b/internal/probe/probe.go
@@ -42,7 +42,7 @@ const (
 
 	eventsMapName            = "events"
 	processExecProgramName   = "tracepoint__syscalls__sys_enter_execve"
-	processCloneProgramName  = "tracepoint__syscalls__sys_exit_clone"
+	processForkProgramName  = "tracepoint__sched__sched_process_fork"
 	processExitProgramName   = "tracepoint__sched__sched_process_exit"
 	pidToContainerPIDMapName = "user_pid_to_container_pid"
 	envPrefixMapName         = "env_prefix"
@@ -187,7 +187,7 @@ func (p *Probe) attach() error {
 	}
 	p.links = append(p.links, l)
 
-	l, err = link.Tracepoint("syscalls", "sys_exit_clone", p.c.Programs[processCloneProgramName], nil)
+	l, err = link.Tracepoint("sched", "sched_process_fork", p.c.Programs[processForkProgramName], nil)
 	if err != nil {
 		return fmt.Errorf("can't attach probe sys_exit_clone: %w", err)
 	}

--- a/internal/probe/probe.go
+++ b/internal/probe/probe.go
@@ -114,10 +114,8 @@ func (p *Probe) load(ns uint32) error {
 	}
 
 	c, err := createCollection(spec, ns)
-	// TODO: remove this log
-	p.logger.Info("error", err)
 	if err != nil && errors.Is(err, ebpf.ErrNotSupported) {
-		p.logger.Warn("BTF not supported, loading eBPF without BTF, some of the features will be disabled")
+		p.logger.Warn("BTF not supported, loading eBPF without BTF, some of the features will be disabled", "error", err)
 		spec, err = loadBpf_no_btf()
 		if err != nil {
 			return err
@@ -190,6 +188,7 @@ func (p *Probe) attach() error {
 	}
 	p.links = append(p.links, l)
 
+	// attach to sched_process_fork tracepoint, first try the version with BTF
 	if prog, ok := p.c.Programs[processForkProgramName]; ok {
 		// attach to raw tracepoint (we have BTF)
 		l, err = link.AttachRawTracepoint((link.RawTracepointOptions{

--- a/internal/probe/probe.go
+++ b/internal/probe/probe.go
@@ -192,9 +192,12 @@ func (p *Probe) attach() error {
 
 	if prog, ok := p.c.Programs[processForkProgramName]; ok {
 		// attach to raw tracepoint (we have BTF)
-		l, err = link.Tracepoint("sched", "sched_process_fork", prog, nil)
+		l, err = link.AttachRawTracepoint((link.RawTracepointOptions{
+			Program: prog,
+			Name:    "sched_process_fork",
+		}))
 		if err != nil {
-			return fmt.Errorf("can't attach probe sched_process_fork: %w", err)
+			return fmt.Errorf("can't attach raw tracepoint sched_process_fork: %w", err)
 		}
 		p.links = append(p.links, l)
 	} else {

--- a/internal/probe/probe.go
+++ b/internal/probe/probe.go
@@ -114,6 +114,8 @@ func (p *Probe) load(ns uint32) error {
 	}
 
 	c, err := createCollection(spec, ns)
+	// TODO: remove this log
+	p.logger.Info("error", err)
 	if err != nil && errors.Is(err, ebpf.ErrNotSupported) {
 		p.logger.Warn("BTF not supported, loading eBPF without BTF, some of the features will be disabled")
 		spec, err = loadBpf_no_btf()

--- a/internal/probe/probe.go
+++ b/internal/probe/probe.go
@@ -41,8 +41,9 @@ const (
 	PerfBufferDefaultSizeInPages = 128
 
 	eventsMapName            = "events"
-	processExecProgramName   = "tracepoint__syscalls__sys_enter_execve"
-	processForkProgramName  = "tracepoint__sched__sched_process_fork"
+	execveSyscallProgramName = "tracepoint__syscalls__sys_enter_execve"
+	processForkProgramName   = "tracepoint__sched__sched_process_fork"
+	processExecProgramName   = "tracepoint__sched__sched_process_exec"
 	processExitProgramName   = "tracepoint__sched__sched_process_exit"
 	pidToContainerPIDMapName = "user_pid_to_container_pid"
 	envPrefixMapName         = "env_prefix"
@@ -175,7 +176,7 @@ func (p *Probe) attach() error {
 	}
 	p.reader = reader
 
-	l, err := link.Tracepoint("syscalls", "sys_enter_execve", p.c.Programs[processExecProgramName], nil)
+	l, err := link.Tracepoint("syscalls", "sys_enter_execve", p.c.Programs[execveSyscallProgramName], nil)
 	if err != nil {
 		return fmt.Errorf("can't attach probe sys_enter_execve: %w", err)
 	}
@@ -189,7 +190,13 @@ func (p *Probe) attach() error {
 
 	l, err = link.Tracepoint("sched", "sched_process_fork", p.c.Programs[processForkProgramName], nil)
 	if err != nil {
-		return fmt.Errorf("can't attach probe sys_exit_clone: %w", err)
+		return fmt.Errorf("can't attach probe sched_process_fork: %w", err)
+	}
+	p.links = append(p.links, l)
+
+	l, err = link.Tracepoint("sched", "sched_process_exec", p.c.Programs[processExecProgramName], nil)
+	if err != nil {
+		return fmt.Errorf("can't attach probe sched_process_exec: %w", err)
 	}
 	p.links = append(p.links, l)
 

--- a/internal/proc/testdata/proc_status_process.txt
+++ b/internal/proc/testdata/proc_status_process.txt
@@ -1,0 +1,61 @@
+Name:	bash
+Umask:	0002
+State:	S (sleeping)
+Tgid:	1402
+Ngid:	0
+Pid:	1402
+PPid:	1401
+TracerPid:	0
+Uid:	1000	1000	1000	1000
+Gid:	1000	1000	1000	1000
+FDSize:	256
+Groups:	4 24 27 30 105 1000
+NStgid:	1402
+NSpid:	1402
+NSpgid:	1402
+NSsid:	1402
+Kthread:	0
+VmPeak:	    9192 kB
+VmSize:	    9192 kB
+VmLck:	       0 kB
+VmPin:	       0 kB
+VmHWM:	    5376 kB
+VmRSS:	    5376 kB
+RssAnon:	    1664 kB
+RssFile:	    3712 kB
+RssShmem:	       0 kB
+VmData:	    1756 kB
+VmStk:	     132 kB
+VmExe:	     956 kB
+VmLib:	    1824 kB
+VmPTE:	      56 kB
+VmSwap:	       0 kB
+HugetlbPages:	       0 kB
+CoreDumping:	0
+THP_enabled:	1
+untag_mask:	0xffffffffffffffff
+Threads:	1
+SigQ:	0/15588
+SigPnd:	0000000000000000
+ShdPnd:	0000000000000000
+SigBlk:	0000000000010000
+SigIgn:	0000000000384004
+SigCgt:	000000004b813efb
+CapInh:	0000000000000000
+CapPrm:	0000000000000000
+CapEff:	0000000000000000
+CapBnd:	000001ffffffffff
+CapAmb:	0000000000000000
+NoNewPrivs:	0
+Seccomp:	0
+Seccomp_filters:	0
+Speculation_Store_Bypass:	vulnerable
+SpeculationIndirectBranch:	always enabled
+Cpus_allowed:	7fff
+Cpus_allowed_list:	0-14
+Mems_allowed:	00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000001
+Mems_allowed_list:	0
+voluntary_ctxt_switches:	33
+nonvoluntary_ctxt_switches:	59
+x86_Thread_features:
+x86_Thread_features_locked:

--- a/internal/proc/testdata/proc_status_thread.txt
+++ b/internal/proc/testdata/proc_status_thread.txt
@@ -1,0 +1,61 @@
+Name:	vi
+Umask:	0022
+State:	S (sleeping)
+Tgid:	3329
+Ngid:	0
+Pid:	3330
+PPid:	2594
+TracerPid:	0
+Uid:	0	0	0	0
+Gid:	0	0	0	0
+FDSize:	256
+Groups:	0
+NStgid:	3329
+NSpid:	3330
+NSpgid:	3329
+NSsid:	2593
+Kthread:	0
+VmPeak:	   25760 kB
+VmSize:	   25692 kB
+VmLck:	       0 kB
+VmPin:	       0 kB
+VmHWM:	   13568 kB
+VmRSS:	   13568 kB
+RssAnon:	    5760 kB
+RssFile:	    7808 kB
+RssShmem:	       0 kB
+VmData:	    6096 kB
+VmStk:	     132 kB
+VmExe:	    3120 kB
+VmLib:	    6484 kB
+VmPTE:	      84 kB
+VmSwap:	       0 kB
+HugetlbPages:	       0 kB
+CoreDumping:	0
+THP_enabled:	1
+untag_mask:	0xffffffffffffffff
+Threads:	2
+SigQ:	2/15588
+SigPnd:	0000000000000000
+ShdPnd:	0000000000000000
+SigBlk:	fffffffe7ffbfeff
+SigIgn:	0000000000003000
+SigCgt:	000000016f8a4eff
+CapInh:	0000000000000000
+CapPrm:	000001ffffffffff
+CapEff:	000001ffffffffff
+CapBnd:	000001ffffffffff
+CapAmb:	0000000000000000
+NoNewPrivs:	0
+Seccomp:	0
+Seccomp_filters:	0
+Speculation_Store_Bypass:	vulnerable
+SpeculationIndirectBranch:	always enabled
+Cpus_allowed:	7fff
+Cpus_allowed_list:	0-14
+Mems_allowed:	00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000001
+Mems_allowed_list:	0
+voluntary_ctxt_switches:	1
+nonvoluntary_ctxt_switches:	0
+x86_Thread_features:
+x86_Thread_features_locked:


### PR DESCRIPTION
This PR adds the ability to track processes that were created by a fork/clone.
We send an event to user space when we detect a new PID being created, and the parent PID is already being tracked.
* When BTF is enabled we can easily verify in eBPF that the created PID is a process and not a thread - and if it is a thread - we won't bother the user space with that event. When we have BTF we are using a raw tracepoint - which means we can read the task struct of the parent and the child.
* When BTF is not enabled, we can't be sure at the clone point if it is a thread or process is created (but we do make sure the parent is tracked before we send an event to user space) - for these cases we verify whether it is a thread or process in user space. When we don't have BTF we use a regular tracepoint and we only have the PIDs of the parent and the child.