### PR TITLE
Fix cmd filter to exe path filter

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,6 +24,7 @@ func main() {
 		detector.WithLogger(l),
 		detector.WithEnvironments("NODE_OPTIONS", "PYTHONPATH", "NODE_VERSION", "PYTHON_VERSION", "JAVA_VERSION", "ODIGOS_POD_NAME", "ODIGOS_CONTAINER_NAME", "ODIGOS_WORKLOAD_NAMESPACE"),
 		detector.WithEnvPrefixFilter("ODIGOS_POD_NAME"),
+		detector.WithExePathsToFilter("/usr/bin/bash", "/bin/bash", "/bin/sh", "/usr/bin/sh", "/bin/busybox", "/usr/bin/dash"),
 	}
 
 	details := make(chan detector.ProcessEvent)

--- a/internal/exePath_filter/exePath_filter.go
+++ b/internal/exePath_filter/exePath_filter.go
@@ -8,8 +8,8 @@ import (
 )
 
 var (
-	// defaultExcludedCmds are the commands that we do not want to track
-	defaultExcludedCmds = map[string]struct{}{
+	// defaultExcludedExePaths are the executables that we do not want to track
+	defaultExcludedExePaths = map[string]struct{}{
 		// it is common for the kubelet/container-runtime to run a process with the command "/pause",
 		"/pause": {},
 	}
@@ -18,42 +18,42 @@ var (
 	GetExeNameFunc = proc.GetExeNameAndLink
 )
 
-// exeNameFilter is a filter that filters processes based on the command they are running.
+// exePathFilter is a filter that filters processes based on the command they are running.
 // TODO: this can be implemented inside eBPF, currently we have it in user space for simplicity, but we can improve this in the future.
-type exeNameFilter struct {
+type exePathFilter struct {
 	l *slog.Logger
 
 	// the consumer of process events supplied by the k8s filter
 	output chan<- common.PIDEvent
 
-	// cmds is a set of commands that we want filter
-	cmds map[string]struct{}
+	// exePaths is a set of commands that we want filter
+	exePaths map[string]struct{}
 
 	// filteredPIDs is a set of pids that we have filtered based on the exe name,
-	// we need to keep track of these pids, so that we can report the exit event when the process exits.
+	// we need to keep track of these pids, so we know not to report the exit event when the process exits.
 	filteredPIDs map[int]struct{}
 }
 
-func NewExePathFilter(l *slog.Logger, cmds []string, output chan<- common.PIDEvent) common.ProcessesFilter {
-	cmdsToFilter := make(map[string]struct{})
+func NewExePathFilter(l *slog.Logger, exePaths []string, output chan<- common.PIDEvent) common.ProcessesFilter {
+	exePathsToFilter := make(map[string]struct{})
 
-	for cmd := range defaultExcludedCmds {
-		cmdsToFilter[cmd] = struct{}{}
+	for exe := range defaultExcludedExePaths {
+		exePathsToFilter[exe] = struct{}{}
 	}
 
-	for _, cmd := range cmds {
-		cmdsToFilter[cmd] = struct{}{}
+	for _, exe := range exePaths {
+		exePathsToFilter[exe] = struct{}{}
 	}
 
-	return &exeNameFilter{
+	return &exePathFilter{
 		l:            l,
 		output:       output,
-		cmds:         cmdsToFilter,
+		exePaths:     exePathsToFilter,
 		filteredPIDs: make(map[int]struct{}),
 	}
 }
 
-func (k *exeNameFilter) Add(pid int) {
+func (k *exePathFilter) Add(pid int) {
 	_, exeName := GetExeNameFunc(pid)
 	if exeName == "" {
 		// this error can happen for 2 reasons:
@@ -65,7 +65,7 @@ func (k *exeNameFilter) Add(pid int) {
 		return
 	}
 
-	if _, ok := k.cmds[exeName]; ok {
+	if _, ok := k.exePaths[exeName]; ok {
 		k.l.Debug("exe name filter skipping pid",
 			"pid", pid,
 			"exe name", exeName,
@@ -76,19 +76,19 @@ func (k *exeNameFilter) Add(pid int) {
 
 	k.output <- common.PIDEvent{Pid: pid, Type: common.EventTypeExec}
 
-	k.l.Debug("cmd filter received pid",
+	k.l.Debug("exe path filter received pid",
 		"pid", pid,
 		"exe name", exeName,
 	)
 }
 
-func (k *exeNameFilter) Close() error {
-	k.l.Info("cmd filter closed")
+func (k *exePathFilter) Close() error {
+	k.l.Info("exe path filter closed")
 	close(k.output)
 	return nil
 }
 
-func (k *exeNameFilter) Remove(pid int) {
+func (k *exePathFilter) Remove(pid int) {
 	_, filtered := k.filteredPIDs[pid]
 	if filtered {
 		delete(k.filteredPIDs, pid)


### PR DESCRIPTION
It makes more sense to filter based on the binary being run and not on the command line (which may include arguments with high cardinality).
This PR fixes the filter to check the executable name and renames the filter and the `DetectorOption` as well.