### PR TITLE
Open notifications

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -12,7 +12,6 @@ import (
 
 func newLogger() *slog.Logger {
 	return slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
-		AddSource: true,
 		Level:     slog.LevelInfo,
 	}))
 }
@@ -32,8 +31,9 @@ func main() {
 	go func() {
 		for d := range details {
 			switch d.EventType {
-			case detector.ProcessExecEvent:
+			case detector.ProcessExecEvent, detector.ProcessFileOpenEvent, detector.ProcessForkEvent:
 				l.Info("detected new process",
+					"eventType", d.EventType.String(),
 					"pid", d.PID,
 					"cmd", d.ExecDetails.CmdLine,
 					"exePath", d.ExecDetails.ExePath,

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/odigos-io/runtime-detector
 
 go 1.22.0
 
-require github.com/cilium/ebpf v0.16.0
+require github.com/cilium/ebpf v0.17.3
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -12,6 +12,5 @@ require (
 
 require (
 	github.com/stretchr/testify v1.9.0
-	golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 // indirect
-	golang.org/x/sys v0.20.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/cilium/ebpf v0.16.0 h1:+BiEnHL6Z7lXnlGUsXQPPAE7+kenAd4ES8MQ5min0Ok=
-github.com/cilium/ebpf v0.16.0/go.mod h1:L7u2Blt2jMM/vLAVgjxluxtBKlz3/GWjB0dMOEngfwE=
+github.com/cilium/ebpf v0.17.3 h1:FnP4r16PWYSE4ux6zN+//jMcW4nMVRvuTLVTvCjyyjg=
+github.com/cilium/ebpf v0.17.3/go.mod h1:G5EDHij8yiLzaqn0WjyfJHvRa+3aDlReIaLVRMvOyJk=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
@@ -24,14 +24,12 @@ github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDN
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 h1:Jvc7gsqn21cJHCmAWx0LiimpP18LZmUxkT5Mp7EZ1mI=
-golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
-golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
-golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
+golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
-golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/common/process_event.go
+++ b/internal/common/process_event.go
@@ -8,6 +8,7 @@ const (
 	EventTypeExec
 	EventTypeExit
 	EventTypeFork
+	EventTypeFileOpen
 )
 
 type PIDEvent struct {
@@ -21,6 +22,10 @@ func (et EventType) String() string {
 		return "exec"
 	case EventTypeExit:
 		return "exit"
+	case EventTypeFork:
+		return "fork"
+	case EventTypeFileOpen:
+		return "file_open"
 	default:
 		return "undefined"
 	}

--- a/internal/common/process_filter.go
+++ b/internal/common/process_filter.go
@@ -5,7 +5,7 @@ package common
 type ProcessesFilter interface {
 	// Add is called when a new process should be inspected by the filter,
 	// or after some changes in the process state occurred which the next filter should be aware of.
-	Add(pid int)
+	Add(pid int, eventType EventType)
 	// Remove is called when a process should be removed from the filter.
 	// If the process in not tracked by the filter, this method should be a no-op.
 	Remove(pid int)

--- a/internal/exePath_filter/exePath_filter.go
+++ b/internal/exePath_filter/exePath_filter.go
@@ -53,7 +53,7 @@ func NewExePathFilter(l *slog.Logger, exePaths []string, output chan<- common.PI
 	}
 }
 
-func (k *exePathFilter) Add(pid int) {
+func (k *exePathFilter) Add(pid int, eventType common.EventType) {
 	_, exePath := GetExePathFunc(pid)
 	if exePath == "" {
 		// this error can happen for 2 reasons:
@@ -74,7 +74,7 @@ func (k *exePathFilter) Add(pid int) {
 		return
 	}
 
-	k.output <- common.PIDEvent{Pid: pid, Type: common.EventTypeExec}
+	k.output <- common.PIDEvent{Pid: pid, Type: eventType}
 
 	k.l.Debug("exe path filter received pid",
 		"pid", pid,

--- a/internal/probe/bpf_arm64_bpfel.go
+++ b/internal/probe/bpf_arm64_bpfel.go
@@ -17,6 +17,11 @@ type bpfEnvPrefixT struct {
 	Prefix [128]uint8
 }
 
+type bpfFilenameT struct {
+	Len uint64
+	Buf [128]uint8
+}
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)
@@ -60,6 +65,7 @@ type bpfSpecs struct {
 type bpfProgramSpecs struct {
 	TracepointSchedSchedProcessExit    *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSyscallsSysEnterExecve   *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_execve"`
+	TracepointSyscallsSysEnterOpenat   *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_openat"`
 	TracepointBtfSchedSchedProcessFork *ebpf.ProgramSpec `ebpf:"tracepoint_btf__sched__sched_process_fork"`
 }
 
@@ -69,6 +75,7 @@ type bpfProgramSpecs struct {
 type bpfMapSpecs struct {
 	EnvPrefix             *ebpf.MapSpec `ebpf:"env_prefix"`
 	Events                *ebpf.MapSpec `ebpf:"events"`
+	PathsToTrack          *ebpf.MapSpec `ebpf:"paths_to_track"`
 	TrackedPidsToNsPids   *ebpf.MapSpec `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.MapSpec `ebpf:"user_pid_to_container_pid"`
 }
@@ -94,6 +101,7 @@ func (o *bpfObjects) Close() error {
 type bpfMaps struct {
 	EnvPrefix             *ebpf.Map `ebpf:"env_prefix"`
 	Events                *ebpf.Map `ebpf:"events"`
+	PathsToTrack          *ebpf.Map `ebpf:"paths_to_track"`
 	TrackedPidsToNsPids   *ebpf.Map `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.Map `ebpf:"user_pid_to_container_pid"`
 }
@@ -102,6 +110,7 @@ func (m *bpfMaps) Close() error {
 	return _BpfClose(
 		m.EnvPrefix,
 		m.Events,
+		m.PathsToTrack,
 		m.TrackedPidsToNsPids,
 		m.UserPidToContainerPid,
 	)
@@ -113,6 +122,7 @@ func (m *bpfMaps) Close() error {
 type bpfPrograms struct {
 	TracepointSchedSchedProcessExit    *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSyscallsSysEnterExecve   *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_execve"`
+	TracepointSyscallsSysEnterOpenat   *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_openat"`
 	TracepointBtfSchedSchedProcessFork *ebpf.Program `ebpf:"tracepoint_btf__sched__sched_process_fork"`
 }
 
@@ -120,6 +130,7 @@ func (p *bpfPrograms) Close() error {
 	return _BpfClose(
 		p.TracepointSchedSchedProcessExit,
 		p.TracepointSyscallsSysEnterExecve,
+		p.TracepointSyscallsSysEnterOpenat,
 		p.TracepointBtfSchedSchedProcessFork,
 	)
 }

--- a/internal/probe/bpf_arm64_bpfel.go
+++ b/internal/probe/bpf_arm64_bpfel.go
@@ -75,7 +75,7 @@ type bpfProgramSpecs struct {
 type bpfMapSpecs struct {
 	EnvPrefix             *ebpf.MapSpec `ebpf:"env_prefix"`
 	Events                *ebpf.MapSpec `ebpf:"events"`
-	PathsToTrack          *ebpf.MapSpec `ebpf:"paths_to_track"`
+	FilesToTrack          *ebpf.MapSpec `ebpf:"files_to_track"`
 	TrackedPidsToNsPids   *ebpf.MapSpec `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.MapSpec `ebpf:"user_pid_to_container_pid"`
 }
@@ -101,7 +101,7 @@ func (o *bpfObjects) Close() error {
 type bpfMaps struct {
 	EnvPrefix             *ebpf.Map `ebpf:"env_prefix"`
 	Events                *ebpf.Map `ebpf:"events"`
-	PathsToTrack          *ebpf.Map `ebpf:"paths_to_track"`
+	FilesToTrack          *ebpf.Map `ebpf:"files_to_track"`
 	TrackedPidsToNsPids   *ebpf.Map `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.Map `ebpf:"user_pid_to_container_pid"`
 }
@@ -110,7 +110,7 @@ func (m *bpfMaps) Close() error {
 	return _BpfClose(
 		m.EnvPrefix,
 		m.Events,
-		m.PathsToTrack,
+		m.FilesToTrack,
 		m.TrackedPidsToNsPids,
 		m.UserPidToContainerPid,
 	)

--- a/internal/probe/bpf_arm64_bpfel.go
+++ b/internal/probe/bpf_arm64_bpfel.go
@@ -57,9 +57,10 @@ func loadBpfObjects(obj interface{}, opts *ebpf.CollectionOptions) error {
 type bpfSpecs struct {
 	bpfProgramSpecs
 	bpfMapSpecs
+	bpfVariableSpecs
 }
 
-// bpfSpecs contains programs before they are loaded into the kernel.
+// bpfProgramSpecs contains programs before they are loaded into the kernel.
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfProgramSpecs struct {
@@ -80,12 +81,21 @@ type bpfMapSpecs struct {
 	UserPidToContainerPid *ebpf.MapSpec `ebpf:"user_pid_to_container_pid"`
 }
 
+// bpfVariableSpecs contains global variables before they are loaded into the kernel.
+//
+// It can be passed ebpf.CollectionSpec.Assign.
+type bpfVariableSpecs struct {
+	ConfiguredPidNsInode *ebpf.VariableSpec `ebpf:"configured_pid_ns_inode"`
+	NumFilesToTrack      *ebpf.VariableSpec `ebpf:"num_files_to_track"`
+}
+
 // bpfObjects contains all objects after they have been loaded into the kernel.
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfObjects struct {
 	bpfPrograms
 	bpfMaps
+	bpfVariables
 }
 
 func (o *bpfObjects) Close() error {
@@ -114,6 +124,14 @@ func (m *bpfMaps) Close() error {
 		m.TrackedPidsToNsPids,
 		m.UserPidToContainerPid,
 	)
+}
+
+// bpfVariables contains all global variables after they have been loaded into the kernel.
+//
+// It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
+type bpfVariables struct {
+	ConfiguredPidNsInode *ebpf.Variable `ebpf:"configured_pid_ns_inode"`
+	NumFilesToTrack      *ebpf.Variable `ebpf:"num_files_to_track"`
 }
 
 // bpfPrograms contains all programs after they have been loaded into the kernel.

--- a/internal/probe/bpf_no_btf_arm64_bpfel.go
+++ b/internal/probe/bpf_no_btf_arm64_bpfel.go
@@ -17,6 +17,11 @@ type bpf_no_btfEnvPrefixT struct {
 	Prefix [128]uint8
 }
 
+type bpf_no_btfFilenameT struct {
+	Len uint64
+	Buf [128]uint8
+}
+
 // loadBpf_no_btf returns the embedded CollectionSpec for bpf_no_btf.
 func loadBpf_no_btf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_Bpf_no_btfBytes)
@@ -61,6 +66,7 @@ type bpf_no_btfProgramSpecs struct {
 	TracepointSchedSchedProcessExit  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSchedSchedProcessFork  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_fork"`
 	TracepointSyscallsSysEnterExecve *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_execve"`
+	TracepointSyscallsSysEnterOpenat *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_openat"`
 }
 
 // bpf_no_btfMapSpecs contains maps before they are loaded into the kernel.
@@ -69,6 +75,7 @@ type bpf_no_btfProgramSpecs struct {
 type bpf_no_btfMapSpecs struct {
 	EnvPrefix             *ebpf.MapSpec `ebpf:"env_prefix"`
 	Events                *ebpf.MapSpec `ebpf:"events"`
+	PathsToTrack          *ebpf.MapSpec `ebpf:"paths_to_track"`
 	TrackedPidsToNsPids   *ebpf.MapSpec `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.MapSpec `ebpf:"user_pid_to_container_pid"`
 }
@@ -94,6 +101,7 @@ func (o *bpf_no_btfObjects) Close() error {
 type bpf_no_btfMaps struct {
 	EnvPrefix             *ebpf.Map `ebpf:"env_prefix"`
 	Events                *ebpf.Map `ebpf:"events"`
+	PathsToTrack          *ebpf.Map `ebpf:"paths_to_track"`
 	TrackedPidsToNsPids   *ebpf.Map `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.Map `ebpf:"user_pid_to_container_pid"`
 }
@@ -102,6 +110,7 @@ func (m *bpf_no_btfMaps) Close() error {
 	return _Bpf_no_btfClose(
 		m.EnvPrefix,
 		m.Events,
+		m.PathsToTrack,
 		m.TrackedPidsToNsPids,
 		m.UserPidToContainerPid,
 	)
@@ -114,6 +123,7 @@ type bpf_no_btfPrograms struct {
 	TracepointSchedSchedProcessExit  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSchedSchedProcessFork  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_fork"`
 	TracepointSyscallsSysEnterExecve *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_execve"`
+	TracepointSyscallsSysEnterOpenat *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_openat"`
 }
 
 func (p *bpf_no_btfPrograms) Close() error {
@@ -121,6 +131,7 @@ func (p *bpf_no_btfPrograms) Close() error {
 		p.TracepointSchedSchedProcessExit,
 		p.TracepointSchedSchedProcessFork,
 		p.TracepointSyscallsSysEnterExecve,
+		p.TracepointSyscallsSysEnterOpenat,
 	)
 }
 

--- a/internal/probe/bpf_no_btf_arm64_bpfel.go
+++ b/internal/probe/bpf_no_btf_arm64_bpfel.go
@@ -75,7 +75,7 @@ type bpf_no_btfProgramSpecs struct {
 type bpf_no_btfMapSpecs struct {
 	EnvPrefix             *ebpf.MapSpec `ebpf:"env_prefix"`
 	Events                *ebpf.MapSpec `ebpf:"events"`
-	PathsToTrack          *ebpf.MapSpec `ebpf:"paths_to_track"`
+	FilesToTrack          *ebpf.MapSpec `ebpf:"files_to_track"`
 	TrackedPidsToNsPids   *ebpf.MapSpec `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.MapSpec `ebpf:"user_pid_to_container_pid"`
 }
@@ -101,7 +101,7 @@ func (o *bpf_no_btfObjects) Close() error {
 type bpf_no_btfMaps struct {
 	EnvPrefix             *ebpf.Map `ebpf:"env_prefix"`
 	Events                *ebpf.Map `ebpf:"events"`
-	PathsToTrack          *ebpf.Map `ebpf:"paths_to_track"`
+	FilesToTrack          *ebpf.Map `ebpf:"files_to_track"`
 	TrackedPidsToNsPids   *ebpf.Map `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.Map `ebpf:"user_pid_to_container_pid"`
 }
@@ -110,7 +110,7 @@ func (m *bpf_no_btfMaps) Close() error {
 	return _Bpf_no_btfClose(
 		m.EnvPrefix,
 		m.Events,
-		m.PathsToTrack,
+		m.FilesToTrack,
 		m.TrackedPidsToNsPids,
 		m.UserPidToContainerPid,
 	)

--- a/internal/probe/bpf_no_btf_arm64_bpfel.go
+++ b/internal/probe/bpf_no_btf_arm64_bpfel.go
@@ -57,9 +57,10 @@ func loadBpf_no_btfObjects(obj interface{}, opts *ebpf.CollectionOptions) error 
 type bpf_no_btfSpecs struct {
 	bpf_no_btfProgramSpecs
 	bpf_no_btfMapSpecs
+	bpf_no_btfVariableSpecs
 }
 
-// bpf_no_btfSpecs contains programs before they are loaded into the kernel.
+// bpf_no_btfProgramSpecs contains programs before they are loaded into the kernel.
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpf_no_btfProgramSpecs struct {
@@ -80,12 +81,21 @@ type bpf_no_btfMapSpecs struct {
 	UserPidToContainerPid *ebpf.MapSpec `ebpf:"user_pid_to_container_pid"`
 }
 
+// bpf_no_btfVariableSpecs contains global variables before they are loaded into the kernel.
+//
+// It can be passed ebpf.CollectionSpec.Assign.
+type bpf_no_btfVariableSpecs struct {
+	ConfiguredPidNsInode *ebpf.VariableSpec `ebpf:"configured_pid_ns_inode"`
+	NumFilesToTrack      *ebpf.VariableSpec `ebpf:"num_files_to_track"`
+}
+
 // bpf_no_btfObjects contains all objects after they have been loaded into the kernel.
 //
 // It can be passed to loadBpf_no_btfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpf_no_btfObjects struct {
 	bpf_no_btfPrograms
 	bpf_no_btfMaps
+	bpf_no_btfVariables
 }
 
 func (o *bpf_no_btfObjects) Close() error {
@@ -114,6 +124,14 @@ func (m *bpf_no_btfMaps) Close() error {
 		m.TrackedPidsToNsPids,
 		m.UserPidToContainerPid,
 	)
+}
+
+// bpf_no_btfVariables contains all global variables after they have been loaded into the kernel.
+//
+// It can be passed to loadBpf_no_btfObjects or ebpf.CollectionSpec.LoadAndAssign.
+type bpf_no_btfVariables struct {
+	ConfiguredPidNsInode *ebpf.Variable `ebpf:"configured_pid_ns_inode"`
+	NumFilesToTrack      *ebpf.Variable `ebpf:"num_files_to_track"`
 }
 
 // bpf_no_btfPrograms contains all programs after they have been loaded into the kernel.

--- a/internal/probe/bpf_no_btf_x86_bpfel.go
+++ b/internal/probe/bpf_no_btf_x86_bpfel.go
@@ -17,6 +17,11 @@ type bpf_no_btfEnvPrefixT struct {
 	Prefix [128]uint8
 }
 
+type bpf_no_btfFilenameT struct {
+	Len uint64
+	Buf [128]uint8
+}
+
 // loadBpf_no_btf returns the embedded CollectionSpec for bpf_no_btf.
 func loadBpf_no_btf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_Bpf_no_btfBytes)
@@ -61,6 +66,7 @@ type bpf_no_btfProgramSpecs struct {
 	TracepointSchedSchedProcessExit  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSchedSchedProcessFork  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_fork"`
 	TracepointSyscallsSysEnterExecve *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_execve"`
+	TracepointSyscallsSysEnterOpenat *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_openat"`
 }
 
 // bpf_no_btfMapSpecs contains maps before they are loaded into the kernel.
@@ -69,6 +75,7 @@ type bpf_no_btfProgramSpecs struct {
 type bpf_no_btfMapSpecs struct {
 	EnvPrefix             *ebpf.MapSpec `ebpf:"env_prefix"`
 	Events                *ebpf.MapSpec `ebpf:"events"`
+	PathsToTrack          *ebpf.MapSpec `ebpf:"paths_to_track"`
 	TrackedPidsToNsPids   *ebpf.MapSpec `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.MapSpec `ebpf:"user_pid_to_container_pid"`
 }
@@ -94,6 +101,7 @@ func (o *bpf_no_btfObjects) Close() error {
 type bpf_no_btfMaps struct {
 	EnvPrefix             *ebpf.Map `ebpf:"env_prefix"`
 	Events                *ebpf.Map `ebpf:"events"`
+	PathsToTrack          *ebpf.Map `ebpf:"paths_to_track"`
 	TrackedPidsToNsPids   *ebpf.Map `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.Map `ebpf:"user_pid_to_container_pid"`
 }
@@ -102,6 +110,7 @@ func (m *bpf_no_btfMaps) Close() error {
 	return _Bpf_no_btfClose(
 		m.EnvPrefix,
 		m.Events,
+		m.PathsToTrack,
 		m.TrackedPidsToNsPids,
 		m.UserPidToContainerPid,
 	)
@@ -114,6 +123,7 @@ type bpf_no_btfPrograms struct {
 	TracepointSchedSchedProcessExit  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSchedSchedProcessFork  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_fork"`
 	TracepointSyscallsSysEnterExecve *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_execve"`
+	TracepointSyscallsSysEnterOpenat *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_openat"`
 }
 
 func (p *bpf_no_btfPrograms) Close() error {
@@ -121,6 +131,7 @@ func (p *bpf_no_btfPrograms) Close() error {
 		p.TracepointSchedSchedProcessExit,
 		p.TracepointSchedSchedProcessFork,
 		p.TracepointSyscallsSysEnterExecve,
+		p.TracepointSyscallsSysEnterOpenat,
 	)
 }
 

--- a/internal/probe/bpf_no_btf_x86_bpfel.go
+++ b/internal/probe/bpf_no_btf_x86_bpfel.go
@@ -75,7 +75,7 @@ type bpf_no_btfProgramSpecs struct {
 type bpf_no_btfMapSpecs struct {
 	EnvPrefix             *ebpf.MapSpec `ebpf:"env_prefix"`
 	Events                *ebpf.MapSpec `ebpf:"events"`
-	PathsToTrack          *ebpf.MapSpec `ebpf:"paths_to_track"`
+	FilesToTrack          *ebpf.MapSpec `ebpf:"files_to_track"`
 	TrackedPidsToNsPids   *ebpf.MapSpec `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.MapSpec `ebpf:"user_pid_to_container_pid"`
 }
@@ -101,7 +101,7 @@ func (o *bpf_no_btfObjects) Close() error {
 type bpf_no_btfMaps struct {
 	EnvPrefix             *ebpf.Map `ebpf:"env_prefix"`
 	Events                *ebpf.Map `ebpf:"events"`
-	PathsToTrack          *ebpf.Map `ebpf:"paths_to_track"`
+	FilesToTrack          *ebpf.Map `ebpf:"files_to_track"`
 	TrackedPidsToNsPids   *ebpf.Map `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.Map `ebpf:"user_pid_to_container_pid"`
 }
@@ -110,7 +110,7 @@ func (m *bpf_no_btfMaps) Close() error {
 	return _Bpf_no_btfClose(
 		m.EnvPrefix,
 		m.Events,
-		m.PathsToTrack,
+		m.FilesToTrack,
 		m.TrackedPidsToNsPids,
 		m.UserPidToContainerPid,
 	)

--- a/internal/probe/bpf_no_btf_x86_bpfel.go
+++ b/internal/probe/bpf_no_btf_x86_bpfel.go
@@ -57,9 +57,10 @@ func loadBpf_no_btfObjects(obj interface{}, opts *ebpf.CollectionOptions) error 
 type bpf_no_btfSpecs struct {
 	bpf_no_btfProgramSpecs
 	bpf_no_btfMapSpecs
+	bpf_no_btfVariableSpecs
 }
 
-// bpf_no_btfSpecs contains programs before they are loaded into the kernel.
+// bpf_no_btfProgramSpecs contains programs before they are loaded into the kernel.
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpf_no_btfProgramSpecs struct {
@@ -80,12 +81,21 @@ type bpf_no_btfMapSpecs struct {
 	UserPidToContainerPid *ebpf.MapSpec `ebpf:"user_pid_to_container_pid"`
 }
 
+// bpf_no_btfVariableSpecs contains global variables before they are loaded into the kernel.
+//
+// It can be passed ebpf.CollectionSpec.Assign.
+type bpf_no_btfVariableSpecs struct {
+	ConfiguredPidNsInode *ebpf.VariableSpec `ebpf:"configured_pid_ns_inode"`
+	NumFilesToTrack      *ebpf.VariableSpec `ebpf:"num_files_to_track"`
+}
+
 // bpf_no_btfObjects contains all objects after they have been loaded into the kernel.
 //
 // It can be passed to loadBpf_no_btfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpf_no_btfObjects struct {
 	bpf_no_btfPrograms
 	bpf_no_btfMaps
+	bpf_no_btfVariables
 }
 
 func (o *bpf_no_btfObjects) Close() error {
@@ -114,6 +124,14 @@ func (m *bpf_no_btfMaps) Close() error {
 		m.TrackedPidsToNsPids,
 		m.UserPidToContainerPid,
 	)
+}
+
+// bpf_no_btfVariables contains all global variables after they have been loaded into the kernel.
+//
+// It can be passed to loadBpf_no_btfObjects or ebpf.CollectionSpec.LoadAndAssign.
+type bpf_no_btfVariables struct {
+	ConfiguredPidNsInode *ebpf.Variable `ebpf:"configured_pid_ns_inode"`
+	NumFilesToTrack      *ebpf.Variable `ebpf:"num_files_to_track"`
 }
 
 // bpf_no_btfPrograms contains all programs after they have been loaded into the kernel.

--- a/internal/probe/bpf_x86_bpfel.go
+++ b/internal/probe/bpf_x86_bpfel.go
@@ -17,6 +17,11 @@ type bpfEnvPrefixT struct {
 	Prefix [128]uint8
 }
 
+type bpfFilenameT struct {
+	Len uint64
+	Buf [128]uint8
+}
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)
@@ -60,6 +65,7 @@ type bpfSpecs struct {
 type bpfProgramSpecs struct {
 	TracepointSchedSchedProcessExit    *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSyscallsSysEnterExecve   *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_execve"`
+	TracepointSyscallsSysEnterOpenat   *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_openat"`
 	TracepointBtfSchedSchedProcessFork *ebpf.ProgramSpec `ebpf:"tracepoint_btf__sched__sched_process_fork"`
 }
 
@@ -69,6 +75,7 @@ type bpfProgramSpecs struct {
 type bpfMapSpecs struct {
 	EnvPrefix             *ebpf.MapSpec `ebpf:"env_prefix"`
 	Events                *ebpf.MapSpec `ebpf:"events"`
+	PathsToTrack          *ebpf.MapSpec `ebpf:"paths_to_track"`
 	TrackedPidsToNsPids   *ebpf.MapSpec `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.MapSpec `ebpf:"user_pid_to_container_pid"`
 }
@@ -94,6 +101,7 @@ func (o *bpfObjects) Close() error {
 type bpfMaps struct {
 	EnvPrefix             *ebpf.Map `ebpf:"env_prefix"`
 	Events                *ebpf.Map `ebpf:"events"`
+	PathsToTrack          *ebpf.Map `ebpf:"paths_to_track"`
 	TrackedPidsToNsPids   *ebpf.Map `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.Map `ebpf:"user_pid_to_container_pid"`
 }
@@ -102,6 +110,7 @@ func (m *bpfMaps) Close() error {
 	return _BpfClose(
 		m.EnvPrefix,
 		m.Events,
+		m.PathsToTrack,
 		m.TrackedPidsToNsPids,
 		m.UserPidToContainerPid,
 	)
@@ -113,6 +122,7 @@ func (m *bpfMaps) Close() error {
 type bpfPrograms struct {
 	TracepointSchedSchedProcessExit    *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSyscallsSysEnterExecve   *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_execve"`
+	TracepointSyscallsSysEnterOpenat   *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_openat"`
 	TracepointBtfSchedSchedProcessFork *ebpf.Program `ebpf:"tracepoint_btf__sched__sched_process_fork"`
 }
 
@@ -120,6 +130,7 @@ func (p *bpfPrograms) Close() error {
 	return _BpfClose(
 		p.TracepointSchedSchedProcessExit,
 		p.TracepointSyscallsSysEnterExecve,
+		p.TracepointSyscallsSysEnterOpenat,
 		p.TracepointBtfSchedSchedProcessFork,
 	)
 }

--- a/internal/probe/bpf_x86_bpfel.go
+++ b/internal/probe/bpf_x86_bpfel.go
@@ -75,7 +75,7 @@ type bpfProgramSpecs struct {
 type bpfMapSpecs struct {
 	EnvPrefix             *ebpf.MapSpec `ebpf:"env_prefix"`
 	Events                *ebpf.MapSpec `ebpf:"events"`
-	PathsToTrack          *ebpf.MapSpec `ebpf:"paths_to_track"`
+	FilesToTrack          *ebpf.MapSpec `ebpf:"files_to_track"`
 	TrackedPidsToNsPids   *ebpf.MapSpec `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.MapSpec `ebpf:"user_pid_to_container_pid"`
 }
@@ -101,7 +101,7 @@ func (o *bpfObjects) Close() error {
 type bpfMaps struct {
 	EnvPrefix             *ebpf.Map `ebpf:"env_prefix"`
 	Events                *ebpf.Map `ebpf:"events"`
-	PathsToTrack          *ebpf.Map `ebpf:"paths_to_track"`
+	FilesToTrack          *ebpf.Map `ebpf:"files_to_track"`
 	TrackedPidsToNsPids   *ebpf.Map `ebpf:"tracked_pids_to_ns_pids"`
 	UserPidToContainerPid *ebpf.Map `ebpf:"user_pid_to_container_pid"`
 }
@@ -110,7 +110,7 @@ func (m *bpfMaps) Close() error {
 	return _BpfClose(
 		m.EnvPrefix,
 		m.Events,
-		m.PathsToTrack,
+		m.FilesToTrack,
 		m.TrackedPidsToNsPids,
 		m.UserPidToContainerPid,
 	)

--- a/internal/probe/bpf_x86_bpfel.go
+++ b/internal/probe/bpf_x86_bpfel.go
@@ -57,9 +57,10 @@ func loadBpfObjects(obj interface{}, opts *ebpf.CollectionOptions) error {
 type bpfSpecs struct {
 	bpfProgramSpecs
 	bpfMapSpecs
+	bpfVariableSpecs
 }
 
-// bpfSpecs contains programs before they are loaded into the kernel.
+// bpfProgramSpecs contains programs before they are loaded into the kernel.
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfProgramSpecs struct {
@@ -80,12 +81,21 @@ type bpfMapSpecs struct {
 	UserPidToContainerPid *ebpf.MapSpec `ebpf:"user_pid_to_container_pid"`
 }
 
+// bpfVariableSpecs contains global variables before they are loaded into the kernel.
+//
+// It can be passed ebpf.CollectionSpec.Assign.
+type bpfVariableSpecs struct {
+	ConfiguredPidNsInode *ebpf.VariableSpec `ebpf:"configured_pid_ns_inode"`
+	NumFilesToTrack      *ebpf.VariableSpec `ebpf:"num_files_to_track"`
+}
+
 // bpfObjects contains all objects after they have been loaded into the kernel.
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfObjects struct {
 	bpfPrograms
 	bpfMaps
+	bpfVariables
 }
 
 func (o *bpfObjects) Close() error {
@@ -114,6 +124,14 @@ func (m *bpfMaps) Close() error {
 		m.TrackedPidsToNsPids,
 		m.UserPidToContainerPid,
 	)
+}
+
+// bpfVariables contains all global variables after they have been loaded into the kernel.
+//
+// It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
+type bpfVariables struct {
+	ConfiguredPidNsInode *ebpf.Variable `ebpf:"configured_pid_ns_inode"`
+	NumFilesToTrack      *ebpf.Variable `ebpf:"num_files_to_track"`
 }
 
 // bpfPrograms contains all programs after they have been loaded into the kernel.

--- a/internal/probe/probe_test.go
+++ b/internal/probe/probe_test.go
@@ -106,6 +106,13 @@ func TestLoad(t *testing.T) {
 		defer p.Close()
 		assert.NoError(t, err)
 
+		v, ok := p.c.Variables[numbFilesConstName]
+		assert.True(t, ok)
+		valFromVar := uint8(0)
+		err = v.Get(&valFromVar)
+		assert.NoError(t, err)
+		assert.Equal(t, uint8(2), valFromVar)
+
 		m := p.c.Maps[filenameMapName]
 		assert.NotNil(t, m)
 

--- a/internal/probe/probe_test.go
+++ b/internal/probe/probe_test.go
@@ -34,6 +34,18 @@ func TestLoad(t *testing.T) {
 		err := p.load(uint32(4026532561))
 		defer p.Close()
 		assert.NoError(t, err)
+
+		m := p.c.Maps[envPrefixMapName]
+		assert.NotNil(t, m)
+
+		value := bpfEnvPrefixT{}
+		err = m.Lookup(uint32(0), &value)
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(len("TEST")), value.Len)
+
+		prefixStr := make([]byte, len("TEST"))
+		copy(prefixStr, value.Prefix[:])
+		assert.Equal(t, []byte("TEST"), prefixStr)
 	})
 
 	t.Run("load with too long env prefix", func(t *testing.T) {
@@ -62,6 +74,50 @@ func TestLoad(t *testing.T) {
 			containerPID, err := p.GetContainerPID(pid)
 			assert.NoError(t, err)
 			assert.Equal(t, 0, containerPID)
+		}
+	})
+
+	t.Run("load with too long file name", func(t *testing.T) {
+		p := &Probe{
+			logger: slog.Default(),
+			openFilesToTrack: []string{repeatedString(129, "a")},
+		}
+		err := p.load(uint32(4026532561))
+		defer p.Close()
+		assert.ErrorContains(t, err, "filename is too long")
+	})
+
+	t.Run("load with too many file names", func(t *testing.T) {
+		p := &Probe{
+			logger: slog.Default(),
+			openFilesToTrack: make([]string, 9),
+		}
+		err := p.load(uint32(4026532561))
+		defer p.Close()
+		assert.ErrorContains(t, err, "too many files to track")
+	})
+
+	t.Run("load with multiple file names", func(t *testing.T) {
+		p := &Probe{
+			logger: slog.Default(),
+			openFilesToTrack: []string{"/var/file1.so", "/var/file2.so"},
+		}
+		err := p.load(uint32(4026532561))
+		defer p.Close()
+		assert.NoError(t, err)
+
+		m := p.c.Maps[filenameMapName]
+		assert.NotNil(t, m)
+
+		for i, file := range p.openFilesToTrack {
+			value := bpfFilenameT{}
+			err = m.Lookup(uint32(i), &value)
+			assert.NoError(t, err)
+			assert.Equal(t, uint64(len(file)), value.Len)
+
+			filename := make([]byte, len(file))
+			copy(filename, value.Buf[:])
+			assert.Equal(t, []byte(file), filename)
 		}
 	})
 }

--- a/internal/probe/probe_test.go
+++ b/internal/probe/probe_test.go
@@ -106,13 +106,6 @@ func TestLoad(t *testing.T) {
 		defer p.Close()
 		assert.NoError(t, err)
 
-		v, ok := p.c.Variables[numbFilesConstName]
-		assert.True(t, ok)
-		valFromVar := uint8(0)
-		err = v.Get(&valFromVar)
-		assert.NoError(t, err)
-		assert.Equal(t, uint8(2), valFromVar)
-
 		m := p.c.Maps[filenameMapName]
 		assert.NotNil(t, m)
 


### PR DESCRIPTION
This PR adds a process event of type `file_open`.
Clients can configure a list of paths which refer to relevant files - if a tracked process would open one of these files, a notification will be sent.
This is done by an additional tracepoint on the `openat` syscall. The tracepoint program won't get loaded if the user didn't specify any path.

As a result, the events being reported to the client now have 4 possible types - exec, fork, file_open and exit.
Follow up PRs include:
1. Moving the exe path filter to eBPF.
2. Improving the duration filter.