### PR TITLE
feat: extract container PID from proc fs on initial scan

### DIFF
--- a/internal/proc/proc_test.go
+++ b/internal/proc/proc_test.go
@@ -234,3 +234,23 @@ func TestIsProcess(t *testing.T) {
 		})
 	}
 }
+
+func TestInnerMostPID(t *testing.T) {
+	t.Run("Valid process in container", func(t *testing.T) {
+		r, err := os.Open("./testdata/proc_status_container.txt")
+		assert.NoError(t, err)
+		defer r.Close()
+		pid, err := innerMostPIDFromReader(r)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, pid)
+	})
+
+	t.Run("Valid process in host", func(t *testing.T) {
+		r, err := os.Open("./testdata/proc_status_process.txt")
+		assert.NoError(t, err)
+		defer r.Close()
+		pid, err := innerMostPIDFromReader(r)
+		assert.NoError(t, err)
+		assert.Equal(t, 1402, pid)
+	})
+}

--- a/internal/proc/testdata/proc_status_container.txt
+++ b/internal/proc/testdata/proc_status_container.txt
@@ -1,0 +1,59 @@
+Name:   java
+Umask:  0022
+State:  S (sleeping)
+Tgid:   9912
+Ngid:   0
+Pid:    9912
+PPid:   9569
+TracerPid:      0
+Uid:    15000   15000   15000   15000
+Gid:    0       0       0       0
+FDSize: 256
+Groups: 0 
+NStgid: 9912    1
+NSpid:  9912    1
+NSpgid: 9912    1
+NSsid:  9912    1
+Kthread:        0
+VmPeak: 15558380 kB
+VmSize:  8684608 kB
+VmLck:         0 kB
+VmPin:         0 kB
+VmHWM:    508788 kB
+VmRSS:    508788 kB
+RssAnon:          478084 kB
+RssFile:           30704 kB
+RssShmem:              0 kB
+VmData:   722020 kB
+VmStk:       132 kB
+VmExe:         8 kB
+VmLib:     17608 kB
+VmPTE:      1568 kB
+VmSwap:        0 kB
+HugetlbPages:          0 kB
+CoreDumping:    0
+THP_enabled:    1
+untag_mask:     0xffffffffffffff
+Threads:        43
+SigQ:   0/63866
+SigPnd: 0000000000000000
+ShdPnd: 0000000000000000
+SigBlk: 0000000000000000
+SigIgn: 0000000000000000
+SigCgt: 2000000101005ccf
+CapInh: 0000000000000000
+CapPrm: 0000000000000000
+CapEff: 0000000000000000
+CapBnd: 00000000a80425fb
+CapAmb: 0000000000000000
+NoNewPrivs:     0
+Seccomp:        0
+Seccomp_filters:        0
+Speculation_Store_Bypass:       thread vulnerable
+SpeculationIndirectBranch:      unknown
+Cpus_allowed:   fff
+Cpus_allowed_list:      0-11
+Mems_allowed:   1
+Mems_allowed_list:      0
+voluntary_ctxt_switches:        23
+nonvoluntary_ctxt_switches:     20


### PR DESCRIPTION
This PR adds the ability to report the container PID on processes which are detected as part of the initial scan.
This adds to the eBPF reporting which read the container PID on new events being reported.
This is done by inspecting the `/proc/<pid>/status` file and reading the NsTgid field - see https://man7.org/linux/man-pages/man5/proc_pid_status.5.html