### PR TITLE
fix: add exe path filtering in user space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM keyval/odiglet-base:v1.5 AS builder
+FROM --platform=$BUILDPLATFORM keyval/odiglet-base:v1.8 AS builder
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,21 @@ generate:
 docker-generate:
 	docker run --rm -v $(shell pwd):/app keyval/odiglet-base:v1.8 /bin/sh -c "cd ../app && make generate"
 
+.PHONY: docker-test
+docker-test:
+	docker run --rm \
+		--privileged \
+		--pid=host \
+		-v $(shell pwd):/app \
+		-v /sys/kernel/debug:/sys/kernel/debug \
+		-v /sys/kernel/tracing:/sys/kernel/tracing \
+		keyval/odiglet-base:v1.8 \
+		/bin/sh -c "cd ../app && make test"
+
+.PHONY: test
+test: generate
+	go test -v ./...
+
 .PHONY: build
 build: generate
 	go build -o runtime-detector ./cmd/...

--- a/detector_test.go
+++ b/detector_test.go
@@ -3,6 +3,7 @@ package detector
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -101,6 +102,13 @@ func TestDetector(t *testing.T) {
 			args:         []string{"-c", "echo hello"},
 			shouldDetect: false,
 		},
+		{
+			name:         "bash script is filtered",
+			envVars:      map[string]string{"USER_ENV": "value"},
+			exePath:      "test/script.sh",
+			args:         []string{},
+			shouldDetect: false,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -121,6 +129,9 @@ func TestDetector(t *testing.T) {
 				WithEnvironments("USER_ENV"),
 				WithEnvPrefixFilter("USER_E"),
 				WithFilesOpenTrigger(testFile, testFile2),
+				WithLogger(slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+					Level: slog.LevelDebug,
+				}))),
 			}
 
 			d, err := NewDetector(events, opts...)

--- a/internal/duration_filter/duration_filter.go
+++ b/internal/duration_filter/duration_filter.go
@@ -9,7 +9,7 @@ import (
 )
 
 type process struct {
-	t        *time.Timer
+	t *time.Timer
 }
 
 type durationFilter struct {
@@ -19,10 +19,10 @@ type durationFilter struct {
 	liveDuration time.Duration
 	closed       bool
 
-	output chan<- common.PIDEvent
+	output common.ProcessesFilter
 }
 
-func NewDurationFilter(logger *slog.Logger, d time.Duration, output chan<- common.PIDEvent) common.ProcessesFilter {
+func NewDurationFilter(logger *slog.Logger, d time.Duration, output common.ProcessesFilter) common.ProcessesFilter {
 	return &durationFilter{
 		procs:        make(map[int]*process),
 		logger:       logger,
@@ -36,7 +36,7 @@ func (df *durationFilter) launchProcessCountdown(pid int, eventType common.Event
 		t: time.AfterFunc(df.liveDuration, func() {
 			df.logger.Debug("process has been active for the specified duration", "pid", pid)
 			// add the pid to the consumer
-			df.output <- common.PIDEvent{Pid: pid, Type: eventType}
+			df.output.Add(pid, eventType)
 			// stop tracking the pid
 			df.mu.Lock()
 			delete(df.procs, pid)
@@ -82,7 +82,7 @@ func (df *durationFilter) Remove(pid int) {
 	}
 
 	// the timer has already fired, we need to notify the consumer about the removal
-	df.output <- common.PIDEvent{Pid: pid, Type: common.EventTypeExit}
+	df.output.Remove(pid)
 }
 
 func (df *durationFilter) Close() error {
@@ -94,7 +94,12 @@ func (df *durationFilter) Close() error {
 		delete(df.procs, pid)
 	}
 
-	close(df.output)
+	if df.output != nil {
+		err := df.output.Close()
+		if err != nil {
+			return err
+		}
+	}
 
 	df.closed = true
 	return nil

--- a/internal/exe_path_filter/exe_path_filter.go
+++ b/internal/exe_path_filter/exe_path_filter.go
@@ -1,0 +1,87 @@
+package exepathfilter
+
+import (
+	"log/slog"
+	"sync"
+
+	"github.com/odigos-io/runtime-detector/internal/common"
+	"github.com/odigos-io/runtime-detector/internal/proc"
+)
+
+// exePathFilter filters process events based on executable paths.
+// This is done in addition to similar filtering done in eBPF.
+// There are some cases that we can cover here that are not covered by our eBPF program,
+// This include a script launched with "./my-script.sh" and the script is interpreted by "/usr/bin/bash"
+// if the user wants to filter out all bash processes, we can do that here.
+type exePathFilter struct {
+	mu               sync.Mutex
+
+	// holds PIDs that have been filtered out based on exe path
+	filteredPIDs     map[int]struct{}
+	exePathsToFilter map[string]struct{}
+	logger           *slog.Logger
+	closed           bool
+
+	output chan<- common.PIDEvent
+}
+
+func NewExePathFilter(logger *slog.Logger, exePathsToFilter map[string]struct{}, output chan<- common.PIDEvent) common.ProcessesFilter {
+	return &exePathFilter{
+		filteredPIDs:     make(map[int]struct{}),
+		exePathsToFilter: exePathsToFilter,
+		logger:           logger,
+		output:           output,
+	}
+}
+
+func (epf *exePathFilter) Add(pid int, eventType common.EventType) {
+	epf.mu.Lock()
+	defer epf.mu.Unlock()
+
+	if epf.closed {
+		epf.logger.Info("cannot add pid, the exe path filter has been closed")
+		return
+	}
+
+	_, exePath := proc.GetExePathAndLink(pid)
+
+	if _, ok := epf.exePathsToFilter[exePath]; ok {
+		epf.logger.Debug("process event filtered out based on exe path",
+			"exePath", exePath,
+			"event type", eventType,
+			"pid", pid,
+		)
+		// Mark this PID as filtered so we don't send exit events for it
+		epf.filteredPIDs[pid] = struct{}{}
+		return
+	}
+
+	epf.logger.Debug("passing process event to next filter", "pid", pid, "eventType", eventType.String())
+	epf.output <- common.PIDEvent{Pid: pid, Type: eventType}
+}
+
+func (epf *exePathFilter) Remove(pid int) {
+	epf.mu.Lock()
+	defer epf.mu.Unlock()
+
+	if _, ok := epf.filteredPIDs[pid]; ok {
+		epf.logger.Debug("not sending exit event for filtered PID", "pid", pid)
+		delete(epf.filteredPIDs, pid)
+		return
+	}
+
+	epf.logger.Debug("passing exit event to next filter", "pid", pid)
+	epf.output <- common.PIDEvent{Pid: pid, Type: common.EventTypeExit}
+}
+
+func (epf *exePathFilter) Close() error {
+	epf.mu.Lock()
+	defer epf.mu.Unlock()
+
+	epf.filteredPIDs = make(map[int]struct{})
+
+	close(epf.output)
+
+	epf.closed = true
+	return nil
+}

--- a/test/script.sh
+++ b/test/script.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Simple bash script for testing
+# This script should be filtered out by the executable name filter
+
+echo "Running bash script"
+
+for i in {1..10}; do
+    sleep 0.08
+done
+
+echo "Bash script completed"


### PR DESCRIPTION
The goal of this PR is to handle cases when processes are launched by calling some script, for example calling `./script.sh` and the script is using `#!/usr/bin/bash` - we want to be able to filter the process event if the detector is configured to ignore `/usr/bin/bash`.
Since currently we are using a tracepoint to the `execve` syscall, we "see" the script.sh as the executable path - and the interpeter path is resolved later in the kernel.
Hence, adding a user space filtering to look at `/proc/pid/exe` - we can see the "actual" exe being run - and filter correctly.