### PR TITLE
Increase the number of environment variables scanned in execve tracepoint

### DIFF
--- a/internal/headers/utils.h
+++ b/internal/headers/utils.h
@@ -1,0 +1,169 @@
+#ifndef UTILS_H
+#define UTILS_H
+
+#include "bpf_helpers.h"
+
+/* Memory iterators used below. */
+#define __it_bwd(x, op) (x -= sizeof(__u##op))
+
+/* Memory operators used below. */
+#define __it_xor(a, b, r, op) r |= (*(__u##op *)__it_bwd(a, op)) ^ (*(__u##op *)__it_bwd(b, op))
+#define __it_set(a, op) (*(__u##op *)__it_bwd(a, op)) = 0
+
+/* an optimized memcmp implementation from Cilium,
+it works by XORing the two inputs at chunks of 8,4 or 2 bytes
+limited to 72 bytes comparisons,
+It helps the verifier by reduce branching complexity and it is more efficient than single byte comparisons */
+static __always_inline bool __bpf_memcmp(const void *x, const void *y, __u64 len) {
+    __u64 r = 0;
+
+    if (!__builtin_constant_p(len)) {
+        __builtin_trap();
+    }
+
+    x += len;
+    y += len;
+
+    if (len > 1 && len % 2 == 1) {
+        __it_xor(x, y, r, 8);
+        len -= 1;
+    }
+
+    switch (len) {
+    case 72:         __it_xor(x, y, r, 64); __attribute__((fallthrough));
+    case 64: jmp_64: __it_xor(x, y, r, 64); __attribute__((fallthrough));
+    case 56: jmp_56: __it_xor(x, y, r, 64); __attribute__((fallthrough));
+    case 48: jmp_48: __it_xor(x, y, r, 64); __attribute__((fallthrough));
+    case 40: jmp_40: __it_xor(x, y, r, 64); __attribute__((fallthrough));
+    case 32: jmp_32: __it_xor(x, y, r, 64); __attribute__((fallthrough));
+    case 24: jmp_24: __it_xor(x, y, r, 64); __attribute__((fallthrough));
+    case 16: jmp_16: __it_xor(x, y, r, 64); __attribute__((fallthrough));
+    case  8: jmp_8:  __it_xor(x, y, r, 64);
+        break;
+
+    case 70: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_64;
+    case 62: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_56;
+    case 54: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_48;
+    case 46: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_40;
+    case 38: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_32;
+    case 30: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_24;
+    case 22: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_16;
+    case 14: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32); goto jmp_8;
+    case  6: __it_xor(x, y, r, 16); __it_xor(x, y, r, 32);
+        break;
+
+    case 68: __it_xor(x, y, r, 32); goto jmp_64;
+    case 60: __it_xor(x, y, r, 32); goto jmp_56;
+    case 52: __it_xor(x, y, r, 32); goto jmp_48;
+    case 44: __it_xor(x, y, r, 32); goto jmp_40;
+    case 36: __it_xor(x, y, r, 32); goto jmp_32;
+    case 28: __it_xor(x, y, r, 32); goto jmp_24;
+    case 20: __it_xor(x, y, r, 32); goto jmp_16;
+    case 12: __it_xor(x, y, r, 32); goto jmp_8;
+    case  4: __it_xor(x, y, r, 32);
+        break;
+
+    case 66: __it_xor(x, y, r, 16); goto jmp_64;
+    case 58: __it_xor(x, y, r, 16); goto jmp_56;
+    case 50: __it_xor(x, y, r, 16); goto jmp_48;
+    case 42: __it_xor(x, y, r, 16); goto jmp_40;
+    case 34: __it_xor(x, y, r, 16); goto jmp_32;
+    case 26: __it_xor(x, y, r, 16); goto jmp_24;
+    case 18: __it_xor(x, y, r, 16); goto jmp_16;
+    case 10: __it_xor(x, y, r, 16); goto jmp_8;
+    case  2: __it_xor(x, y, r, 16);
+        break;
+
+    case  1: __it_xor(x, y, r, 8);
+        break;
+
+    default:
+        __builtin_trap();
+    }
+
+    return r == 0;
+}
+
+static __always_inline void __bpf_memzero(void *d, __u64 len)
+{
+	if (!__builtin_constant_p(len))
+		__builtin_trap();
+
+	d += len;
+
+	if (len > 1 && len % 2 == 1) {
+		__it_set(d, 8);
+		len -= 1;
+	}
+
+	switch (len) {
+	case 96:         __it_set(d, 64); __attribute__((fallthrough));
+	case 88: jmp_88: __it_set(d, 64); __attribute__((fallthrough));
+	case 80: jmp_80: __it_set(d, 64); __attribute__((fallthrough));
+	case 72: jmp_72: __it_set(d, 64); __attribute__((fallthrough));
+	case 64: jmp_64: __it_set(d, 64); __attribute__((fallthrough));
+	case 56: jmp_56: __it_set(d, 64); __attribute__((fallthrough));
+	case 48: jmp_48: __it_set(d, 64); __attribute__((fallthrough));
+	case 40: jmp_40: __it_set(d, 64); __attribute__((fallthrough));
+	case 32: jmp_32: __it_set(d, 64); __attribute__((fallthrough));
+	case 24: jmp_24: __it_set(d, 64); __attribute__((fallthrough));
+	case 16: jmp_16: __it_set(d, 64); __attribute__((fallthrough));
+	case  8: jmp_8:  __it_set(d, 64);
+		break;
+
+	case 94: __it_set(d, 16); __it_set(d, 32); goto jmp_88;
+	case 86: __it_set(d, 16); __it_set(d, 32); goto jmp_80;
+	case 78: __it_set(d, 16); __it_set(d, 32); goto jmp_72;
+	case 70: __it_set(d, 16); __it_set(d, 32); goto jmp_64;
+	case 62: __it_set(d, 16); __it_set(d, 32); goto jmp_56;
+	case 54: __it_set(d, 16); __it_set(d, 32); goto jmp_48;
+	case 46: __it_set(d, 16); __it_set(d, 32); goto jmp_40;
+	case 38: __it_set(d, 16); __it_set(d, 32); goto jmp_32;
+	case 30: __it_set(d, 16); __it_set(d, 32); goto jmp_24;
+	case 22: __it_set(d, 16); __it_set(d, 32); goto jmp_16;
+	case 14: __it_set(d, 16); __it_set(d, 32); goto jmp_8;
+	case  6: __it_set(d, 16); __it_set(d, 32);
+		break;
+
+	case 92: __it_set(d, 32); goto jmp_88;
+	case 84: __it_set(d, 32); goto jmp_80;
+	case 76: __it_set(d, 32); goto jmp_72;
+	case 68: __it_set(d, 32); goto jmp_64;
+	case 60: __it_set(d, 32); goto jmp_56;
+	case 52: __it_set(d, 32); goto jmp_48;
+	case 44: __it_set(d, 32); goto jmp_40;
+	case 36: __it_set(d, 32); goto jmp_32;
+	case 28: __it_set(d, 32); goto jmp_24;
+	case 20: __it_set(d, 32); goto jmp_16;
+	case 12: __it_set(d, 32); goto jmp_8;
+	case  4: __it_set(d, 32);
+		break;
+
+	case 90: __it_set(d, 16); goto jmp_88;
+	case 82: __it_set(d, 16); goto jmp_80;
+	case 74: __it_set(d, 16); goto jmp_72;
+	case 66: __it_set(d, 16); goto jmp_64;
+	case 58: __it_set(d, 16); goto jmp_56;
+	case 50: __it_set(d, 16); goto jmp_48;
+	case 42: __it_set(d, 16); goto jmp_40;
+	case 34: __it_set(d, 16); goto jmp_32;
+	case 26: __it_set(d, 16); goto jmp_24;
+	case 18: __it_set(d, 16); goto jmp_16;
+	case 10: __it_set(d, 16); goto jmp_8;
+	case  2: __it_set(d, 16);
+		break;
+
+	case  1: __it_set(d, 8);
+		break;
+
+	default:
+		/* __builtin_memset() is crappy slow since it cannot
+		 * make any assumptions about alignment & underlying
+		 * efficient unaligned access on the target we're
+		 * running.
+		 */
+		__builtin_trap();
+	}
+}
+
+#endif

--- a/internal/probe/bpf_arm64_bpfel.go
+++ b/internal/probe/bpf_arm64_bpfel.go
@@ -16,7 +16,7 @@ import (
 type bpfEnvPrefixT struct {
 	_      structs.HostLayout
 	Len    uint64
-	Prefix [128]uint8
+	Prefix [32]uint8
 }
 
 type bpfExecFilenameT struct {

--- a/internal/probe/bpf_arm64_bpfel.go
+++ b/internal/probe/bpf_arm64_bpfel.go
@@ -16,7 +16,7 @@ import (
 type bpfEnvPrefixT struct {
 	_      structs.HostLayout
 	Len    uint64
-	Prefix [32]uint8
+	Prefix [16]uint8
 }
 
 type bpfExecFilenameT struct {

--- a/internal/probe/bpf_no_btf_arm64_bpfel.go
+++ b/internal/probe/bpf_no_btf_arm64_bpfel.go
@@ -16,7 +16,7 @@ import (
 type bpf_no_btfEnvPrefixT struct {
 	_      structs.HostLayout
 	Len    uint64
-	Prefix [128]uint8
+	Prefix [32]uint8
 }
 
 type bpf_no_btfExecFilenameT struct {

--- a/internal/probe/bpf_no_btf_arm64_bpfel.go
+++ b/internal/probe/bpf_no_btf_arm64_bpfel.go
@@ -16,7 +16,7 @@ import (
 type bpf_no_btfEnvPrefixT struct {
 	_      structs.HostLayout
 	Len    uint64
-	Prefix [32]uint8
+	Prefix [16]uint8
 }
 
 type bpf_no_btfExecFilenameT struct {

--- a/internal/probe/bpf_no_btf_x86_bpfel.go
+++ b/internal/probe/bpf_no_btf_x86_bpfel.go
@@ -16,7 +16,7 @@ import (
 type bpf_no_btfEnvPrefixT struct {
 	_      structs.HostLayout
 	Len    uint64
-	Prefix [128]uint8
+	Prefix [32]uint8
 }
 
 type bpf_no_btfExecFilenameT struct {

--- a/internal/probe/bpf_no_btf_x86_bpfel.go
+++ b/internal/probe/bpf_no_btf_x86_bpfel.go
@@ -16,7 +16,7 @@ import (
 type bpf_no_btfEnvPrefixT struct {
 	_      structs.HostLayout
 	Len    uint64
-	Prefix [32]uint8
+	Prefix [16]uint8
 }
 
 type bpf_no_btfExecFilenameT struct {

--- a/internal/probe/bpf_x86_bpfel.go
+++ b/internal/probe/bpf_x86_bpfel.go
@@ -16,7 +16,7 @@ import (
 type bpfEnvPrefixT struct {
 	_      structs.HostLayout
 	Len    uint64
-	Prefix [128]uint8
+	Prefix [32]uint8
 }
 
 type bpfExecFilenameT struct {

--- a/internal/probe/bpf_x86_bpfel.go
+++ b/internal/probe/bpf_x86_bpfel.go
@@ -16,7 +16,7 @@ import (
 type bpfEnvPrefixT struct {
 	_      structs.HostLayout
 	Len    uint64
-	Prefix [32]uint8
+	Prefix [16]uint8
 }
 
 type bpfExecFilenameT struct {

--- a/internal/probe/ebpf/detector.bpf.c
+++ b/internal/probe/ebpf/detector.bpf.c
@@ -17,7 +17,7 @@ char __license[] SEC("license") = "Dual MIT/GPL";
 // The maximum length of the prefix we are looking for in the environment variables.
 #define MAX_ENV_PREFIX_LEN        (128)
 #define MAX_ENV_PREFIX_MASK       ((MAX_ENV_PREFIX_LEN) - 1)
-#define MAX_ENV_VARS              (128)
+#define MAX_ENV_VARS              (4096)
 
 // The maximum length of the executable pathname to filter out.
 #define MAX_EXEC_PATHNAME_LEN     (64)

--- a/internal/probe/ebpf/detector.bpf.c
+++ b/internal/probe/ebpf/detector.bpf.c
@@ -15,9 +15,9 @@ char __license[] SEC("license") = "Dual MIT/GPL";
 #define MAX_CONCURRENT_PIDS       (16384) // 2^14
 
 // The maximum length of the prefix we are looking for in the environment variables.
-#define MAX_ENV_PREFIX_LEN        (128)
+#define MAX_ENV_PREFIX_LEN        (32)
 #define MAX_ENV_PREFIX_MASK       ((MAX_ENV_PREFIX_LEN) - 1)
-#define MAX_ENV_VARS              (4096)
+#define MAX_ENV_VARS              (1024)
 
 // The maximum length of the executable pathname to filter out.
 #define MAX_EXEC_PATHNAME_LEN     (64)
@@ -278,10 +278,6 @@ int tracepoint__syscalls__sys_enter_execve(struct syscall_trace_enter* ctx) {
         ret = bpf_probe_read_user(&argp, sizeof(argp), &args[i]);
         if (ret < 0) {
             return 0;
-        }
-
-        if (argp == NULL) {
-            break;
         }
 
         ret = bpf_probe_read_user_str(&buf[0], sizeof(buf), argp);

--- a/internal/probe/ebpf/detector.bpf.c
+++ b/internal/probe/ebpf/detector.bpf.c
@@ -15,7 +15,7 @@ char __license[] SEC("license") = "Dual MIT/GPL";
 #define MAX_CONCURRENT_PIDS       (16384) // 2^14
 
 // The maximum length of the prefix we are looking for in the environment variables.
-#define MAX_ENV_PREFIX_LEN        (32)
+#define MAX_ENV_PREFIX_LEN        (16)
 #define MAX_ENV_PREFIX_MASK       ((MAX_ENV_PREFIX_LEN) - 1)
 #define MAX_ENV_VARS              (1024)
 

--- a/internal/probe/ebpf/detector.bpf.c
+++ b/internal/probe/ebpf/detector.bpf.c
@@ -271,6 +271,9 @@ int tracepoint__syscalls__sys_enter_execve(struct syscall_trace_enter* ctx) {
     // only read up to the configured prefix length
     // if the configured prefix is shorter than MAX_ENV_PREFIX_LEN,
     // the buffer will have the contents [<max prefix length bytes>, 0, 0 ,...0]
+    // this allows us to always use a constant-size compare function
+    // (comparing MAX_ENV_PREFIX_LEN bytes) in an optimized way
+    // and a verifier-friendly way.
     u32 size_to_read = configured_prefix->len;
     if (size_to_read > MAX_ENV_PREFIX_LEN) {
         // user space should validate the env prefix passed, this should not happen if user space verifies the prefix length

--- a/internal/probe/probe_test.go
+++ b/internal/probe/probe_test.go
@@ -28,7 +28,7 @@ func TestLoad(t *testing.T) {
 	t.Run("load with env prefix", func(t *testing.T) {
 		p := &Probe{
 			logger:          slog.Default(),
-			envPrefixFilter: "TEST",
+			envPrefixFilter: "ODIGOS_POD_NAME",
 		}
 		err := p.load(uint32(4026532561))
 		defer p.Close()
@@ -40,11 +40,11 @@ func TestLoad(t *testing.T) {
 		value := bpfEnvPrefixT{}
 		err = m.Lookup(uint32(0), &value)
 		assert.NoError(t, err)
-		assert.Equal(t, uint64(len("TEST")), value.Len)
+		assert.Equal(t, uint64(len("ODIGOS_POD_NAME")), value.Len)
 
-		prefixStr := make([]byte, len("TEST"))
+		prefixStr := make([]byte, len("ODIGOS_POD_NAME"))
 		copy(prefixStr, value.Prefix[:])
-		assert.Equal(t, []byte("TEST"), prefixStr)
+		assert.Equal(t, []byte("ODIGOS_POD_NAME"), prefixStr)
 	})
 
 	t.Run("load with too long env prefix", func(t *testing.T) {


### PR DESCRIPTION
The goal of this PR is to provide a hot-fix for increasing the amount of environment variable the eBPF code can scan. It is increased from 128 to 1024.
This is possible by 2 changes:
1. Reducing the max env prefix length from 64 to 16 - it still satisfies any practical use of this feature and allows to reduce the loop complexity for the verifier.
2. Using an optimized compare function that does a compare on a constant size. This size is currently 16 - and the env prefix can be configured to be shorter than that and the buffers being compared will be padded with zero bytes in that case.

As future improvemnts:
* Report to user space when we encounter a process that has more env vars than what we can support.