### PR TITLE
fix: handle page fault errors when reading envs

### DIFF
--- a/detector.go
+++ b/detector.go
@@ -219,7 +219,12 @@ func (d *Detector) procEventLoop() {
 					}
 				}
 				if !foundEnvPrefix {
-					d.l.Warn("skipping process event due to env prefix not present", "pid", e.Pid, "envPrefixFilter", d.envPrefixFilter)
+					d.l.Warn("skipping process event due to env prefix not present",
+						"pid", e.Pid,
+						"envPrefixFilter", d.envPrefixFilter,
+						"cmdLine", execDetails.CmdLine,
+						"exePath", execDetails.ExePath,
+					)
 					d.pidsFilteredByEnvPrefix[e.Pid] = struct{}{}
 					continue
 				}


### PR DESCRIPTION
This PR slightly changes the algorithm for env prefix filtering:
* If we reached a NULL pointer in the `envp` vector we return and not pass a process exec event. This happens often when we successfully scan the env vector of an un-relevant process.
* If we read an env pointer successfully but fail to de-reference it and read the underlying string - we have no certainty about the envs - and this can happen if the memory referenced by the env pointer is not paged in yet. In this case we continue as if we found a relevant env prefix.

emergency-ticket id: EMR-1
