### PR TITLE
fix: report exec event from syscall exit instead of syscall entry

### DIFF
--- a/detector.go
+++ b/detector.go
@@ -97,6 +97,7 @@ type ProcessExecDetails struct {
 type detectorConfig struct {
 	logger           *slog.Logger
 	minDuration      time.Duration
+	durationPassed   bool
 	envs             map[string]struct{}
 	envPrefixFilter  string
 	exePathsToFilter map[string]struct{}
@@ -335,7 +336,7 @@ func newConfig(opts []DetectorOption) (detectorConfig, error) {
 		c.logger = newDefaultLogger()
 	}
 
-	if c.minDuration == 0 {
+	if !c.durationPassed {
 		c.minDuration = defaultMinDuration
 	}
 
@@ -364,9 +365,11 @@ func WithLogger(l *slog.Logger) DetectorOption {
 
 // WithMinDuration returns a [DetectorOption] that configures a [Detector] to use the specified minimum duration
 // for a process to be considered active, the default is 1 second. This is used to filter out short-lived processes.
+// Passing a zero duration will result in a passthrough filter, which will not filter any processes.
 func WithMinDuration(d time.Duration) DetectorOption {
 	return fnOpt(func(c detectorConfig) (detectorConfig, error) {
 		c.minDuration = d
+		c.durationPassed = true
 		return c, nil
 	})
 }

--- a/internal/probe/bpf_arm64_bpfel.go
+++ b/internal/probe/bpf_arm64_bpfel.go
@@ -76,6 +76,7 @@ type bpfProgramSpecs struct {
 	TracepointSchedSchedProcessExit    *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSyscallsSysEnterExecve   *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_execve"`
 	TracepointSyscallsSysEnterOpenat   *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_openat"`
+	TracepointSyscallsSysExitExecve    *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_exit_execve"`
 	TracepointBtfSchedSchedProcessFork *ebpf.ProgramSpec `ebpf:"tracepoint_btf__sched__sched_process_fork"`
 }
 
@@ -155,6 +156,7 @@ type bpfPrograms struct {
 	TracepointSchedSchedProcessExit    *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSyscallsSysEnterExecve   *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_execve"`
 	TracepointSyscallsSysEnterOpenat   *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_openat"`
+	TracepointSyscallsSysExitExecve    *ebpf.Program `ebpf:"tracepoint__syscalls__sys_exit_execve"`
 	TracepointBtfSchedSchedProcessFork *ebpf.Program `ebpf:"tracepoint_btf__sched__sched_process_fork"`
 }
 
@@ -163,6 +165,7 @@ func (p *bpfPrograms) Close() error {
 		p.TracepointSchedSchedProcessExit,
 		p.TracepointSyscallsSysEnterExecve,
 		p.TracepointSyscallsSysEnterOpenat,
+		p.TracepointSyscallsSysExitExecve,
 		p.TracepointBtfSchedSchedProcessFork,
 	)
 }

--- a/internal/probe/bpf_no_btf_arm64_bpfel.go
+++ b/internal/probe/bpf_no_btf_arm64_bpfel.go
@@ -77,6 +77,7 @@ type bpf_no_btfProgramSpecs struct {
 	TracepointSchedSchedProcessFork  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_fork"`
 	TracepointSyscallsSysEnterExecve *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_execve"`
 	TracepointSyscallsSysEnterOpenat *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_openat"`
+	TracepointSyscallsSysExitExecve  *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_exit_execve"`
 }
 
 // bpf_no_btfMapSpecs contains maps before they are loaded into the kernel.
@@ -156,6 +157,7 @@ type bpf_no_btfPrograms struct {
 	TracepointSchedSchedProcessFork  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_fork"`
 	TracepointSyscallsSysEnterExecve *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_execve"`
 	TracepointSyscallsSysEnterOpenat *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_openat"`
+	TracepointSyscallsSysExitExecve  *ebpf.Program `ebpf:"tracepoint__syscalls__sys_exit_execve"`
 }
 
 func (p *bpf_no_btfPrograms) Close() error {
@@ -164,6 +166,7 @@ func (p *bpf_no_btfPrograms) Close() error {
 		p.TracepointSchedSchedProcessFork,
 		p.TracepointSyscallsSysEnterExecve,
 		p.TracepointSyscallsSysEnterOpenat,
+		p.TracepointSyscallsSysExitExecve,
 	)
 }
 

--- a/internal/probe/bpf_no_btf_x86_bpfel.go
+++ b/internal/probe/bpf_no_btf_x86_bpfel.go
@@ -77,6 +77,7 @@ type bpf_no_btfProgramSpecs struct {
 	TracepointSchedSchedProcessFork  *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_fork"`
 	TracepointSyscallsSysEnterExecve *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_execve"`
 	TracepointSyscallsSysEnterOpenat *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_openat"`
+	TracepointSyscallsSysExitExecve  *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_exit_execve"`
 }
 
 // bpf_no_btfMapSpecs contains maps before they are loaded into the kernel.
@@ -156,6 +157,7 @@ type bpf_no_btfPrograms struct {
 	TracepointSchedSchedProcessFork  *ebpf.Program `ebpf:"tracepoint__sched__sched_process_fork"`
 	TracepointSyscallsSysEnterExecve *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_execve"`
 	TracepointSyscallsSysEnterOpenat *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_openat"`
+	TracepointSyscallsSysExitExecve  *ebpf.Program `ebpf:"tracepoint__syscalls__sys_exit_execve"`
 }
 
 func (p *bpf_no_btfPrograms) Close() error {
@@ -164,6 +166,7 @@ func (p *bpf_no_btfPrograms) Close() error {
 		p.TracepointSchedSchedProcessFork,
 		p.TracepointSyscallsSysEnterExecve,
 		p.TracepointSyscallsSysEnterOpenat,
+		p.TracepointSyscallsSysExitExecve,
 	)
 }
 

--- a/internal/probe/bpf_x86_bpfel.go
+++ b/internal/probe/bpf_x86_bpfel.go
@@ -76,6 +76,7 @@ type bpfProgramSpecs struct {
 	TracepointSchedSchedProcessExit    *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSyscallsSysEnterExecve   *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_execve"`
 	TracepointSyscallsSysEnterOpenat   *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_openat"`
+	TracepointSyscallsSysExitExecve    *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_exit_execve"`
 	TracepointBtfSchedSchedProcessFork *ebpf.ProgramSpec `ebpf:"tracepoint_btf__sched__sched_process_fork"`
 }
 
@@ -155,6 +156,7 @@ type bpfPrograms struct {
 	TracepointSchedSchedProcessExit    *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
 	TracepointSyscallsSysEnterExecve   *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_execve"`
 	TracepointSyscallsSysEnterOpenat   *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_openat"`
+	TracepointSyscallsSysExitExecve    *ebpf.Program `ebpf:"tracepoint__syscalls__sys_exit_execve"`
 	TracepointBtfSchedSchedProcessFork *ebpf.Program `ebpf:"tracepoint_btf__sched__sched_process_fork"`
 }
 
@@ -163,6 +165,7 @@ func (p *bpfPrograms) Close() error {
 		p.TracepointSchedSchedProcessExit,
 		p.TracepointSyscallsSysEnterExecve,
 		p.TracepointSyscallsSysEnterOpenat,
+		p.TracepointSyscallsSysExitExecve,
 		p.TracepointBtfSchedSchedProcessFork,
 	)
 }

--- a/internal/probe/probe.go
+++ b/internal/probe/probe.go
@@ -45,6 +45,7 @@ const (
 
 	eventsMapName               = "events"
 	execveSyscallProgramName    = "tracepoint__syscalls__sys_enter_execve"
+	execveSyscallExitProgramName = "tracepoint__syscalls__sys_exit_execve"
 	processForkNoBTFProgramName = "tracepoint__sched__sched_process_fork"
 	processForkProgramName      = "tracepoint_btf__sched__sched_process_fork"
 	processExitProgramName      = "tracepoint__sched__sched_process_exit"
@@ -237,6 +238,12 @@ func (p *Probe) attach() error {
 	l, err := link.Tracepoint("syscalls", "sys_enter_execve", p.c.Programs[execveSyscallProgramName], nil)
 	if err != nil {
 		return fmt.Errorf("can't attach probe sys_enter_execve: %w", err)
+	}
+	p.links = append(p.links, l)
+
+	l, err = link.Tracepoint("syscalls", "sys_exit_execve", p.c.Programs[execveSyscallExitProgramName], nil)
+	if err != nil {
+		return fmt.Errorf("can't attach probe sys_exit_execve: %w", err)
 	}
 	p.links = append(p.links, l)
 


### PR DESCRIPTION
Durrng testing and reducing the duration filter to zero, observed that processes can have the `/proc` files in an unstable state - probably not ready yet.
This lead to logs liks:
```
{"time":"2025-08-04T11:40:17.084570751Z","level":"WARN","msg":"skipping process event due to env prefix not present","pid":6186,"envPrefixFilter":"ODIGOS_POD_NAME","cmdLine":"runc init","exePath":"/membership"}
```
The `cmdline` and the exe link seems inconsistent. In addition the `environ` files does not contain the expected env vars - which leads to the filtering of the event.
Adding an exit tracepoint to the `eceve` syscall and reporting to user space from there solves that behavior.

In addition, the `duration_filter` will be used as a passthrough filter if the duration passed is zero.

emergency-ticket id: EMR-5
