### PR TITLE
[RUN-112] feat: support mounted /proc fs to avoid requirement to hostPid namespace

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -36,6 +36,11 @@ func main() {
 		),
 	}
 
+	procFS, ok := os.LookupEnv("HOST_PROCFS")
+	if ok && procFS != "" {
+		opts = append(opts, detector.WithProcFSPath(procFS))
+	}
+
 	details := make(chan detector.ProcessEvent)
 	done := make(chan struct{})
 	go func() {

--- a/daemonset.yaml
+++ b/daemonset.yaml
@@ -21,15 +21,27 @@ spec:
       # imagePullPolicy: Always
         name: runtime-detector
         resources: {}
+        env:
+        - name: HOST_PROCFS
+          value: /hostproc
         securityContext:
-          privileged: true
+          privileged: false
+          capabilities:
+            add:
+            - BPF
+            - PERFMON
+            - SYS_PTRACE
+            - DAC_READ_SEARCH
+            drop:
+            - ALL
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /sys/kernel/debug
           name: kernel-debug
+        - mountPath: /hostproc
+          name: host-proc
       dnsPolicy: ClusterFirst
-      hostPID: true
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
@@ -39,3 +51,7 @@ spec:
         hostPath:
           path: /sys/kernel/debug
           type: ""
+      - name: host-proc
+        hostPath:
+          path: /proc
+          type: Directory

--- a/internal/probe/probe.go
+++ b/internal/probe/probe.go
@@ -92,9 +92,9 @@ func New(logger *slog.Logger, f common.ProcessesFilter, config Config) *Probe {
 
 func (p *Probe) LoadAndAttach() error {
 	// find the PID namespace inode
-	pidNS, err := proc.GetCurrentPIDNameSpaceIndoe()
+	pidNS, err := proc.GetHostPIDNameSpaceIndoe()
 	if err != nil {
-		return fmt.Errorf("can't get current PID namespace inode: %w", err)
+		return fmt.Errorf("can't get host PID namespace inode: %w", err)
 	}
 
 	if err := p.load(pidNS); err != nil {

--- a/internal/proc/proc.go
+++ b/internal/proc/proc.go
@@ -20,7 +20,12 @@ func procFile(pid int, filename string) string {
 	return fmt.Sprintf("%s/%d/%s", procFS, pid, filename)
 }
 
-func GetCurrentPIDNameSpaceIndoe() (uint32, error) {
+// SetProcFSPath allows to set the path to the proc filesystem.
+func SetProcFSPath(path string) {
+	procFS = path
+}
+
+func GetHostPIDNameSpaceIndoe() (uint32, error) {
 	// look at the pid namespace of the root process
 	path := procFile(1, "ns/pid")
 	content, err := os.Readlink(path)


### PR DESCRIPTION
This PR aims to reduce the permissions, mounts and host namespaces sharing of the detector.
* Adding a detector option to allow users to configure the location of the proc filesystem. This is done to remove the requirement for setting `hostPID: true`.
* The example CLI and daemonset are updated to reflect the change.