### PR TITLE
update cilium/ebpf dependency to not include commit with ringbuf bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/odigos-io/runtime-detector
 
 go 1.24.0
 
-require github.com/cilium/ebpf v0.19.1-0.20250818092626-ae226118949d
+require github.com/cilium/ebpf v0.19.1-0.20250815145053-c9de60689836
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/cilium/ebpf v0.19.1-0.20250818092626-ae226118949d h1:53XY3TeudeY1tPentx/Uf0FLMzq1op9dwdPJ5QaTCFc=
-github.com/cilium/ebpf v0.19.1-0.20250818092626-ae226118949d/go.mod h1:GMSzJItnG6k1OEtplNHr66oI/BlTcGTS/oE7lO4kOGU=
+github.com/cilium/ebpf v0.19.1-0.20250815145053-c9de60689836 h1:TB5syj60+4qF/xIpef+qWgzsCi1XEV1BVSxYT78ibWY=
+github.com/cilium/ebpf v0.19.1-0.20250815145053-c9de60689836/go.mod h1:GMSzJItnG6k1OEtplNHr66oI/BlTcGTS/oE7lO4kOGU=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6 h1:teYtXy9B7y5lHTp8V9KPxpYRAVA7dozigQcMiBust1s=


### PR DESCRIPTION
following #34, the main branch of `cilium/ebpf` contained a bug in `ringbuf` which is now under review,
taking the commit version one commit back to avoid the regression introduced in `ringbuf`.

emergency-ticket id: EMR-167
