### PR TITLE
Support fallback to root pid namespace

### DIFF
--- a/internal/probe/probe.go
+++ b/internal/probe/probe.go
@@ -94,7 +94,13 @@ func (p *Probe) LoadAndAttach() error {
 	// find the PID namespace inode
 	pidNS, err := proc.GetHostPIDNameSpaceIndoe()
 	if err != nil {
-		return fmt.Errorf("can't get host PID namespace inode: %w", err)
+		p.logger.Warn(
+			"failed to get host pid namespace. Processes will be reported with the host pid namespace "+
+				"assuming the host /proc dir is mounted and we can examine the reported events correctly",
+			"error", err,
+		)
+		// making sure the pid ns is set to 0, indicating the eBPF programs to report the host/root ns PID
+		pidNS = 0
 	}
 
 	if err := p.load(pidNS); err != nil {


### PR DESCRIPTION
if we failed to read the root pid ns, fallback to reporting PIDs in that ns and avoid returning an error.
Cases where the pid ns is crucial is when the detector is running inside a container without access to the host pid ns.
When running in k8s, as long as the host /proc dir is mounted the detector can function properly even without knowing the pid ns.

emergency-ticket id: EMR-222
